### PR TITLE
initialize member variables

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -29,6 +29,7 @@
 AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC)
 {
   portNo = port;
+  i2sOn = false;
 #ifdef ESP32
   if (!i2sOn) {
     i2s_config_t i2s_config_dac = {


### PR DESCRIPTION
if AudioOutputI2S is instanciated in a function (like in the examples) the member variables are not initialized to a default value.