### PR TITLE
make use_apll user-configurable (fixes #37)

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -26,18 +26,20 @@
 #endif
 #include "AudioOutputI2S.h"
 
-AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC)
+AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC, int use_apll)
 {
   portNo = port;
   i2sOn = false;
 #ifdef ESP32
   if (!i2sOn) {
-    // don't use audio pll on buggy rev0 chips
-    int use_apll = 0;
-    esp_chip_info_t out_info;
-    esp_chip_info(&out_info);
-    if(out_info.revision > 0) {
-      use_apll = 1;
+    if (use_apll < 0) { // set use_apll to 0 or 1 to force dis-/enable
+      // don't use audio pll on buggy rev0 chips
+      use_apll = 0;
+      esp_chip_info_t out_info;
+      esp_chip_info(&out_info);
+      if(out_info.revision > 0) {
+        use_apll = 1;
+      }
     }
     i2s_config_t i2s_config_dac = {
       .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | (builtInDAC ? I2S_MODE_DAC_BUILT_IN : 0)),

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -32,13 +32,13 @@ AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC, int use_apll)
   i2sOn = false;
 #ifdef ESP32
   if (!i2sOn) {
-    if (use_apll < 0) { // set use_apll to 0 or 1 to force dis-/enable
+    if (use_apll == APLL_AUTO) {
       // don't use audio pll on buggy rev0 chips
-      use_apll = 0;
+      use_apll = APLL_DISABLE;
       esp_chip_info_t out_info;
       esp_chip_info(&out_info);
       if(out_info.revision > 0) {
-        use_apll = 1;
+        use_apll = APLL_ENABLE;
       }
     }
     i2s_config_t i2s_config_dac = {

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -23,10 +23,17 @@
 
 #include "AudioOutput.h"
 
+enum i2s_apll_mode : int
+{
+  APLL_AUTO = -1,
+  APLL_ENABLE = 1,
+  APLL_DISABLE = 0
+};
+
 class AudioOutputI2S : public AudioOutput
 {
   public:
-    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=-1);
+    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=APLL_AUTO);
     virtual ~AudioOutputI2S() override;
     bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual bool SetRate(int hz) override;

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -26,7 +26,7 @@
 class AudioOutputI2S : public AudioOutput
 {
   public:
-    AudioOutputI2S(int port=0, bool builtInDAC=false);
+    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=-1);
     virtual ~AudioOutputI2S() override;
     bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual bool SetRate(int hz) override;

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -23,13 +23,6 @@
 
 #include "AudioOutput.h"
 
-enum i2s_apll_mode : int
-{
-  APLL_AUTO = -1,
-  APLL_ENABLE = 1,
-  APLL_DISABLE = 0
-};
-
 class AudioOutputI2S : public AudioOutput
 {
   public:
@@ -44,7 +37,9 @@ class AudioOutputI2S : public AudioOutput
     virtual bool stop() override;
     
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
-    
+
+    enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
+
   protected:
     virtual int AdjustI2SRate(int hz) { return hz; }
     uint8_t portNo;


### PR DESCRIPTION
I don't know if this is an acceptable way to solve the apll issues:
Since the usability of the apll seems to depend on the chip/board and probably has to be handled by the user ... we could introduce another esp32-specific variable in the constructor to make it user-configurable.
default value of -1 is auto-detect by revision number (like before).