### PR TITLE
handle esp32 apll issues

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -26,18 +26,20 @@
 #endif
 #include "AudioOutputI2S.h"
 
-AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC)
+AudioOutputI2S::AudioOutputI2S(int port, bool builtInDAC, int use_apll)
 {
   portNo = port;
   i2sOn = false;
 #ifdef ESP32
   if (!i2sOn) {
-    // don't use audio pll on buggy rev0 chips
-    int use_apll = 0;
-    esp_chip_info_t out_info;
-    esp_chip_info(&out_info);
-    if(out_info.revision > 0) {
-      use_apll = 1;
+    if (use_apll == APLL_AUTO) {
+      // don't use audio pll on buggy rev0 chips
+      use_apll = APLL_DISABLE;
+      esp_chip_info_t out_info;
+      esp_chip_info(&out_info);
+      if(out_info.revision > 0) {
+        use_apll = APLL_ENABLE;
+      }
     }
     i2s_config_t i2s_config_dac = {
       .mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX | (builtInDAC ? I2S_MODE_DAC_BUILT_IN : 0)),

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -26,7 +26,7 @@
 class AudioOutputI2S : public AudioOutput
 {
   public:
-    AudioOutputI2S(int port=0, bool builtInDAC=false);
+    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=APLL_AUTO);
     virtual ~AudioOutputI2S() override;
     bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual bool SetRate(int hz) override;
@@ -37,7 +37,9 @@ class AudioOutputI2S : public AudioOutput
     virtual bool stop() override;
     
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
-    
+
+    enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
+
   protected:
     virtual int AdjustI2SRate(int hz) { return hz; }
     uint8_t portNo;

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -26,7 +26,7 @@
 class AudioOutputI2S : public AudioOutput
 {
   public:
-    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=APLL_AUTO);
+    AudioOutputI2S(int port=0, bool builtInDAC=false, int use_apll=APLL_DISABLE);
     virtual ~AudioOutputI2S() override;
     bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual bool SetRate(int hz) override;


### PR DESCRIPTION
enabling APLL seems to cause issues on multiple ESP32 boards. see issues #37 and #47.

a) make it user-configurable to allow the user to handle it for the specific board.
b) and revert to the old behavior and disable apll per default.

(this superseedes pull request #45)