### PR TITLE
report buffer fill level

### DIFF
--- a/src/AudioFileSourceBuffer.cpp
+++ b/src/AudioFileSourceBuffer.cpp
@@ -85,6 +85,11 @@ uint32_t AudioFileSourceBuffer::getPos()
   return src->getPos();
 }
 
+uint32_t AudioFileSourceBuffer::getFillLevel()
+{
+  return length;
+}
+
 uint32_t AudioFileSourceBuffer::read(void *data, uint32_t len)
 {
   if (!buffer) return src->read(data, len);

--- a/src/AudioFileSourceBuffer.h
+++ b/src/AudioFileSourceBuffer.h
@@ -39,6 +39,8 @@ class AudioFileSourceBuffer : public AudioFileSource
     virtual uint32_t getPos() override;
     virtual bool loop() override;
 
+    virtual uint32_t getFillLevel();
+
     enum { STATUS_FILLING=2, STATUS_UNDERFLOW };
 
   private:


### PR DESCRIPTION
I'd like to draw the buffer fill level on a screen in order to debug streaming issues. unfortunately all of this is hidden inside the AudioFileSourceBuffer class. Can we make that accessible from outside?