### PR TITLE
make dma_buf_count configurable by user, so we can have a larger dma buffer on ESP32

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -26,7 +26,7 @@
 #endif
 #include "AudioOutputI2S.h"
 
-AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int use_apll)
+AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int use_apll)
 {
   this->portNo = port;
   this->i2sOn = false;
@@ -65,7 +65,7 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int use_apll)
       .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
       .communication_format = comm_fmt,
       .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // high interrupt priority
-      .dma_buf_count = 8,
+      .dma_buf_count = dma_buf_count,
       .dma_buf_len = 64,   //Interrupt level 1
       .use_apll = use_apll // Use audio PLL
     };

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -64,9 +64,9 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
       .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
       .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
       .communication_format = comm_fmt,
-      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // high interrupt priority
+      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // lowest interrupt priority
       .dma_buf_count = dma_buf_count,
-      .dma_buf_len = 64,   //Interrupt level 1
+      .dma_buf_len = 64,
       .use_apll = use_apll // Use audio PLL
     };
     Serial.printf("+%d %p\n", portNo, &i2s_config_dac);

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -26,7 +26,7 @@
 class AudioOutputI2S : public AudioOutput
 {
   public:
-    AudioOutputI2S(int port=0, int output_mode=EXTERNAL_I2S, int use_apll=APLL_DISABLE);
+    AudioOutputI2S(int port=0, int output_mode=EXTERNAL_I2S, int dma_buf_count = 8, int use_apll=APLL_DISABLE);
     virtual ~AudioOutputI2S() override;
     bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual bool SetRate(int hz) override;


### PR DESCRIPTION
The ESP32 has enough RAM to justify spending a bit more on the DMA buffer. So make the number of buffers configurable in the constructor.

This would allow us to spend more time in-between decoder->loop() calls. i.e. call it from an FreeRTOS task and do a longer vTaskDelay() (probably also in case of short decoding errors.)

WARNING: This changes the type signature of the constructor AudioOutputI2S. If you've previously called it with 3 arguments, this will break your code. Unfortunately this won't be at compile-time because both arguments are of the same type.