### PR TITLE
replace esp32s i2s_push_sample()

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -188,7 +188,7 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
   } else {
     s32 = ((Amplify(ms[RIGHTCHANNEL]))<<16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
   }
-  return i2s_push_sample((i2s_port_t)portNo, (const char *)&s32, 0);
+  return i2s_write_bytes((i2s_port_t)portNo, &s32, sizeof(uint32_t), 0);
 #else
   uint32_t s32 = ((Amplify(ms[RIGHTCHANNEL]))<<16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
   return i2s_write_sample_nb(s32); // If we can't store it, return false.  OTW true


### PR DESCRIPTION
as it is deprecated and changed behaviour between esp-idf v2.0 and v3.0. this fixes the chipmunks in #110 and #105

please note that i2s_write_bytes() is also deprecated now. we should probably use i2s_write() as mentioned in #105 but that isn't introduced until esp-idf v3.0