### PR TITLE
increase max buffer size beyond 64k

### DIFF
--- a/src/AudioFileSourceBuffer.h
+++ b/src/AudioFileSourceBuffer.h
@@ -27,8 +27,8 @@
 class AudioFileSourceBuffer : public AudioFileSource
 {
   public:
-    AudioFileSourceBuffer(AudioFileSource *in, int bufferBytes);
-    AudioFileSourceBuffer(AudioFileSource *in, void *buffer, int bufferBytes); // Pre-allocated buffer by app
+    AudioFileSourceBuffer(AudioFileSource *in, uint32_t bufferBytes);
+    AudioFileSourceBuffer(AudioFileSource *in, void *buffer, uint32_t bufferBytes); // Pre-allocated buffer by app
     virtual ~AudioFileSourceBuffer() override;
     
     virtual uint32_t read(void *data, uint32_t len) override;
@@ -48,12 +48,12 @@ class AudioFileSourceBuffer : public AudioFileSource
 
   private:
     AudioFileSource *src;
-    uint16_t buffSize;
+    uint32_t buffSize;
     uint8_t *buffer;
     bool deallocateBuffer;
-    uint16_t writePtr;
-    uint16_t readPtr;
-    uint16_t length;
+    uint32_t writePtr;
+    uint32_t readPtr;
+    uint32_t length;
     bool filled;
 };
 


### PR DESCRIPTION
The ESP32 can easily handle a buffer size greater than UINT16_MAX (64KB)
so make the size an uint32_t.