### PR TITLE
Buffer pre-fill

### DIFF
--- a/src/AudioFileSourceBuffer.cpp
+++ b/src/AudioFileSourceBuffer.cpp
@@ -170,6 +170,26 @@ void AudioFileSourceBuffer::fill()
   }
 }
 
+bool AudioFileSourceBuffer::fill(uint32_t len, uint32_t max_delay)
+{
+  if (!src->isOpen()) {
+    Serial.printf_P(PSTR("Source file not open\n"));
+    return false;
+  }
+  if (!src->loop()) return false;
+  fill();
+
+  uint32_t toFill = (len < buffSize) ? len : buffSize;
+  uint32_t startTimestamp = millis();
+  while (length < toFill && millis() - startTimestamp < max_delay) {
+    delay(100);
+    if (!src->loop()) return false;
+    fill();
+  }
+  if (length < len) return false;
+  return true;
+}
+
 
 
 bool AudioFileSourceBuffer::loop()

--- a/src/AudioFileSourceBuffer.cpp
+++ b/src/AudioFileSourceBuffer.cpp
@@ -33,7 +33,6 @@ AudioFileSourceBuffer::AudioFileSourceBuffer(AudioFileSource *source, uint32_t b
   readPtr = 0;
   src = source;
   length = 0;
-  filled = false;
 }
 
 AudioFileSourceBuffer::AudioFileSourceBuffer(AudioFileSource *source, void *inBuff, uint32_t buffSizeBytes)
@@ -45,7 +44,6 @@ AudioFileSourceBuffer::AudioFileSourceBuffer(AudioFileSource *source, void *inBu
   readPtr = 0;
   src = source;
   length = 0;
-  filled = false;
 }
 
 AudioFileSourceBuffer::~AudioFileSourceBuffer()
@@ -95,12 +93,11 @@ uint32_t AudioFileSourceBuffer::read(void *data, uint32_t len)
   if (!buffer) return src->read(data, len);
 
   uint32_t bytes = 0;
-  if (!filled) {
+  if (length == 0) {
     // Fill up completely before returning any data at all
     cb.st(STATUS_FILLING, PSTR("Refilling buffer"));
     length = src->read(buffer, buffSize);
     writePtr = length % buffSize;
-    filled = true;
   }
 
   // Pull from buffer until we've got none left or we've satisfied the request
@@ -133,7 +130,6 @@ uint32_t AudioFileSourceBuffer::read(void *data, uint32_t len)
     readPtr = 0;
     writePtr = 0;
     length = 0;
-    filled = false;
     cb.st(STATUS_UNDERFLOW, PSTR("Buffer underflow"));
   }
 

--- a/src/AudioFileSourceBuffer.h
+++ b/src/AudioFileSourceBuffer.h
@@ -39,6 +39,7 @@ class AudioFileSourceBuffer : public AudioFileSource
     virtual uint32_t getPos() override;
     virtual bool loop() override;
 
+    virtual bool fill(uint32_t len, uint32_t max_delay);
     virtual uint32_t getFillLevel();
 
     enum { STATUS_FILLING=2, STATUS_UNDERFLOW };

--- a/src/AudioFileSourceBuffer.h
+++ b/src/AudioFileSourceBuffer.h
@@ -54,7 +54,6 @@ class AudioFileSourceBuffer : public AudioFileSource
     uint32_t writePtr;
     uint32_t readPtr;
     uint32_t length;
-    bool filled;
 };
 
 


### PR DESCRIPTION
allow the user to pre-fill the AudioFileSourceBuffer before calling out.begin()