### PR TITLE
don't try to read 0 bytes if we hit the icy block (fixes #124)

### DIFF
--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -167,6 +167,7 @@ retry:
     int ret = 0;
     if (beforeIcy > 0) {
       ret = stream->read(reinterpret_cast<uint8_t*>(data), beforeIcy);
+      if (ret < 0) ret = 0;
       read += ret;
       pos += ret;
       len -= ret;
@@ -228,6 +229,7 @@ retry:
   }
 
   int ret = stream->read(reinterpret_cast<uint8_t*>(data), len);
+  if (ret < 0) ret = 0;
   read += ret;
   pos += ret;
   icyByteCount += ret;

--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -164,13 +164,16 @@ retry:
   // If the read would hit an ICY block, split it up...
   if (((int)(icyByteCount + len) > (int)icyMetaInt) && (icyMetaInt > 0)) {
     int beforeIcy = icyMetaInt - icyByteCount;
-    int ret = stream->read(reinterpret_cast<uint8_t*>(data), beforeIcy);
-    read += ret;
-    pos += ret;
-    len -= ret;
-    data = (void *)(reinterpret_cast<char*>(data) + ret);
-    icyByteCount += ret;
-    if (ret != beforeIcy) return read; // Partial read
+    int ret = 0;
+    if (beforeIcy > 0) {
+      ret = stream->read(reinterpret_cast<uint8_t*>(data), beforeIcy);
+      read += ret;
+      pos += ret;
+      len -= ret;
+      data = (void *)(reinterpret_cast<char*>(data) + ret);
+      icyByteCount += ret;
+      if (ret != beforeIcy) return read; // Partial read
+    }
 
     uint8_t mdSize;
     int mdret = stream->read(&mdSize, 1);


### PR DESCRIPTION
beforeIcy can become 0 in:
https://github.com/earlephilhower/ESP8266Audio/blob/135e912f3ef435f763e4a68b2dc22da6d33ebc85/src/AudioFileSourceICYStream.cpp#L166
which causes a read of 0 bytes in the next line and subsequently makes ICYStream stop reading anything. this was the cause of the buffer underrun in #124 in the fist place.

unfortunately not easy to reproduce.

Also WiFiClient.read() can return -1 which messes with the length arithmetic. ~~I'll also add a commit for that.~~ ( https://github.com/espressif/arduino-esp32/blob/a0f0bd930cfd2d607bf3d3288f46e2d265dd2e11/libraries/WiFi/src/WiFiClient.cpp#L101 )

EDIT: And messing with the arithmetic might be the thing why it stops reading after that. So instead of merging this pull-request we could do the 0-bytes read and then:
`if (ret < 0) ret = 0;`

(and there is another stream->read() at the end of the function which could return -1)