### PR TITLE
Tell AudioOutputMixer the rate for the next sample

### DIFF
--- a/src/AudioOutputMixer.cpp
+++ b/src/AudioOutputMixer.cpp
@@ -35,7 +35,9 @@ AudioOutputMixerStub::~AudioOutputMixerStub()
 
 bool AudioOutputMixerStub::SetRate(int hz)
 {
-  return parent->SetRate(hz, id);
+  myHz = hz;
+
+  return true;
 }
 
 bool AudioOutputMixerStub::SetBitsPerSample(int bits)
@@ -58,6 +60,7 @@ bool AudioOutputMixerStub::ConsumeSample(int16_t sample[2])
   int16_t amp[2];
   amp[LEFTCHANNEL] = Amplify(sample[LEFTCHANNEL]);
   amp[RIGHTCHANNEL] = Amplify(sample[RIGHTCHANNEL]);
+  parent->SetRate(myHz);
   return parent->ConsumeSample(amp, id);
 }
 

--- a/src/AudioOutputMixer.h
+++ b/src/AudioOutputMixer.h
@@ -42,6 +42,7 @@ class AudioOutputMixerStub : public AudioOutput
   protected:
     AudioOutputMixer *parent;
     int id;
+    int myHz;
 };
 
 // Single mixer object per output


### PR DESCRIPTION
This seems to solve #128.

I tried this again with the example code from #128 and both, the music and the effect, did sound as they should when played at the correct sampling rate.