### PR TITLE
Call output->stop() when stopping generators

### DIFF
--- a/src/AudioGeneratorFLAC.cpp
+++ b/src/AudioGeneratorFLAC.cpp
@@ -126,7 +126,7 @@ bool AudioGeneratorFLAC::stop()
     FLAC__stream_decoder_delete(flac);
   flac = NULL;
   running = false;
-  
+  output->stop();
   return true;
 }
 

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -585,6 +585,7 @@ done:
 bool AudioGeneratorMIDI::stop()
 {
   StopMIDI();
+  output->stop();
   return true;
 }
 

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -70,6 +70,7 @@ bool AudioGeneratorMOD::stop()
   }
   if (file) file->close();
   running = false;
+  output->stop();
   return true;
 }
 

--- a/src/AudioGeneratorMP3a.cpp
+++ b/src/AudioGeneratorMP3a.cpp
@@ -53,6 +53,7 @@ bool AudioGeneratorMP3a::stop()
 {
   if (!running) return true;
   running = false;
+  output->stop();
   return file->close();
 }
 

--- a/src/AudioGeneratorRTTTL.cpp
+++ b/src/AudioGeneratorRTTTL.cpp
@@ -43,6 +43,7 @@ bool AudioGeneratorRTTTL::stop()
 {
   if (!running) return true;
   running = false;
+  output->stop();
   return file->close();
 }
 

--- a/src/AudioGeneratorWAV.cpp
+++ b/src/AudioGeneratorWAV.cpp
@@ -44,6 +44,7 @@ bool AudioGeneratorWAV::stop()
   running = false;
   free(buff);
   buff = NULL;
+  output->stop();
   return file->close();
 }
 


### PR DESCRIPTION
When using I2S on ESP32, i2s_zero_dma_buffer must be called when stopping playback to avoid hanging sound. This was implemented in AudioOutputI2S.cpp stop() method, but the call to this method from generators has only been added in the MP3 generator and not in other generator.

This PR adds a call to output->stop() in every generator stop() method except for MP3 generator which already had this call.

This PR fixes #149 

Best,