### PR TITLE
Added possibility to change DOUT pin.

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -77,12 +77,11 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
       i2s_set_pin((i2s_port_t)portNo, NULL);
       i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
     } else {
-      SetPinout(26, 25, 22);
+      SetPinout(26, 25, AudioOutputI2S::DOUT);
     }
     i2s_zero_dma_buffer((i2s_port_t)portNo);
   } 
 #else
-  (void) dma_buf_count;
   (void) use_apll;
   if (!i2sOn) {
     i2s_begin();

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -40,6 +40,8 @@ class AudioOutputI2S : public AudioOutput
 
     enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
     enum : int { EXTERNAL_I2S = 0, INTERNAL_DAC = 1, INTERNAL_PDM = 2 };
+    
+    static int DOUT;
 
   protected:
     virtual int AdjustI2SRate(int hz) { return hz; }


### PR DESCRIPTION
Use `AudioOutputI2S::DOUT = 27;` before creating any instance of `AudioOutputI2S`.

If you use I2C as well, do not forget to add pull-up resistors on SDA and SCL lines to avoid any problem ;)