### PR TITLE
Document the internal DAC on ESP32 more explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ AudioGeneratorRTTTL:  Enjoy the pleasures of monophonic, 4-octave ringtones on y
 ## AudioOutput classes
 AudioOutput:  Base class for all output drivers.  Takes a sample at a time and returns true/false if there is buffer space for it.  If it returns false, it is the calling object's (AudioGenerator's) job to keep the data that didn't fit and try again later.
 
-AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz.
+AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz. To use the internal DAC on ESP32, instantiate this class as `AudioOutputI2S(0,1)`, see example `PlayMODFromPROGMEMToDAC` and code in [AudioOutputI2S.cpp](src/AudioOutputI2S.cpp#L29) for details.
 
 AudioOutputI2SNoDAC:  Abuses the I2S interface to play music without a DAC.  Turns it into a 32x (or higher) oversampling delta-sigma DAC.  Use the schematic below to drive a speaker or headphone from the I2STx pin (i.e. Rx).  Note that with this interface, depending on the transistor used, you may need to disconnect the Rx pin from the driver to perform serial uploads.  Mono-only output, of course.
 

--- a/examples/PlayMODFromPROGMEMToDAC/PlayMODFromPROGMEMToDAC.ino
+++ b/examples/PlayMODFromPROGMEMToDAC/PlayMODFromPROGMEMToDAC.ino
@@ -21,6 +21,7 @@ void setup()
   Serial.begin(115200);
   delay(1000);
   file = new AudioFileSourcePROGMEM( enigma_mod, sizeof(enigma_mod) );
+  // out = new AudioOutputI2S(0, 1); Uncomment this line, comment the next one to use the internal DAC channel 1 (pin25) on ESP32
   out = new AudioOutputI2S();
   mod = new AudioGeneratorMOD();
   mod->SetBufferSize(3*1024);


### PR DESCRIPTION
I expected the internal DAC of ESP32 to be more clearly documented and to be included in the examples.
This PR adds some documentation to the Readme as well as a comment in example PlayMODFromPROGMEMToDAC.

As it seems to be a tradition: bravo et merci for this fantastic library!