### PR TITLE
AAC endianness

### DIFF
--- a/src/libhelix-aac/assembly.h
+++ b/src/libhelix-aac/assembly.h
@@ -558,9 +558,14 @@ static __inline int CLZ(int x)
 typedef union _U64 {
 	Word64 w64;
 	struct {
+#ifdef __XTENSA__		
+		unsigned int lo32;
+		signed int   hi32;
+#else
 		/* PowerPC = big endian */
 		signed int   hi32;
 		unsigned int lo32;
+#endif		
 	} r;
 } U64;
 


### PR DESCRIPTION
ARDUINO #define defaults to PowerPC which is the wrong order for ESP32. Still, there might be a better #define to use rather than __XTSENSA__