### PR TITLE
Free BCK and WS pins for general use with NoDAC

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -85,8 +85,8 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
   (void) dma_buf_count;
   (void) use_apll;
   if (!i2sOn) {
-	orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
-	orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
+    orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
+    orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
     i2s_begin();
   }
 #endif

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -85,6 +85,8 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
   (void) dma_buf_count;
   (void) use_apll;
   if (!i2sOn) {
+	orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
+	orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
     i2s_begin();
   }
 #endif

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -47,9 +47,9 @@ class AudioOutputI2S : public AudioOutput
     int output_mode;
     bool mono;
     bool i2sOn;
-	// We can restore the old values and free up these pins when in NoDAC mode
-	uint32_t orig_bck;
-	uint32_t orig_ws;
+    // We can restore the old values and free up these pins when in NoDAC mode
+    uint32_t orig_bck;
+    uint32_t orig_ws;
 };
 
 #endif

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -47,6 +47,9 @@ class AudioOutputI2S : public AudioOutput
     int output_mode;
     bool mono;
     bool i2sOn;
+	// We can restore the old values and free up these pins when in NoDAC mode
+	uint32_t orig_bck;
+	uint32_t orig_ws;
 };
 
 #endif

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -32,8 +32,10 @@ AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port) : AudioOutputI2S(port, false)
   SetOversampling(32);
   lastSamp = 0;
   cumErr = 0;
+#ifndef ESP32
   WRITE_PERI_REG(PERIPHS_IO_MUX_MTDO_U, orig_bck);
   WRITE_PERI_REG(PERIPHS_IO_MUX_GPIO2_U, orig_ws);
+#endif
 }
 
 AudioOutputI2SNoDAC::~AudioOutputI2SNoDAC()

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -32,6 +32,8 @@ AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port) : AudioOutputI2S(port, false)
   SetOversampling(32);
   lastSamp = 0;
   cumErr = 0;
+  WRITE_PERI_REG(PERIPHS_IO_MUX_MTDO_U, orig_bck);
+  WRITE_PERI_REG(PERIPHS_IO_MUX_GPIO2_U, orig_ws);
 }
 
 AudioOutputI2SNoDAC::~AudioOutputI2SNoDAC()


### PR DESCRIPTION
The BCK and WS pins aren't needed or used when using the I2SNoDAC
option.  Restore their settings to whatever they were before, leaving
them untouched.  Apps may configure the additional pins either before or
after the I2SNoDac is created.