### PR TITLE
Fix ESP32 compilation, add SPI class RAM wrapper

### DIFF
--- a/src/AudioFileSourceSPIRAMBuffer.cpp
+++ b/src/AudioFileSourceSPIRAMBuffer.cpp
@@ -29,139 +29,139 @@
 
 AudioFileSourceSPIRAMBuffer::AudioFileSourceSPIRAMBuffer(AudioFileSource *source, uint8_t csPin, uint32_t buffSizeBytes)
 {
-	ram.begin(40, csPin);
-	ramSize = buffSizeBytes;
-	writePtr = 0;
-	readPtr = 0;
-	filled = false;
-	src = source;
-	audioLogger->printf_P(PSTR("SPI RAM buffer size: %u Bytes\n"), ramSize);
+    ram.begin(40, csPin);
+    ramSize = buffSizeBytes;
+    writePtr = 0;
+    readPtr = 0;
+    filled = false;
+    src = source;
+    audioLogger->printf_P(PSTR("SPI RAM buffer size: %u Bytes\n"), ramSize);
 }
 
 AudioFileSourceSPIRAMBuffer::~AudioFileSourceSPIRAMBuffer()
 {
-	ram.end();
+    ram.end();
 }
 
 bool AudioFileSourceSPIRAMBuffer::seek(int32_t pos, int dir)
 {
-	// Invalidate
-	readPtr = 0;
-	writePtr = 0;
-	filled = false;
-	return src->seek(pos, dir);
+    // Invalidate
+    readPtr = 0;
+    writePtr = 0;
+    filled = false;
+    return src->seek(pos, dir);
 }
 
 bool AudioFileSourceSPIRAMBuffer::close()
 {
-	return src->close();
+    return src->close();
 }
 
 bool AudioFileSourceSPIRAMBuffer::isOpen()
 {
-	return src->isOpen();
+    return src->isOpen();
 }
 
 uint32_t AudioFileSourceSPIRAMBuffer::getSize()
 {
-	return src->getSize();
+    return src->getSize();
 }
 
 uint32_t AudioFileSourceSPIRAMBuffer::getPos()
 {
-	return src->getPos() - (writePtr - readPtr);
+    return src->getPos() - (writePtr - readPtr);
 }
 
 uint32_t AudioFileSourceSPIRAMBuffer::read(void *data, uint32_t len)
 {
-	uint32_t bytes = 0;
+    uint32_t bytes = 0;
 
-	// Check if the buffer isn't empty, otherwise we try to fill completely
-	if (!filled) {
-		cb.st(999, PSTR("Filling buffer..."));
-		uint8_t buffer[256];
-		writePtr = 0;
-		readPtr = 0;
-		// Fill up completely before returning any data at all
-		do {
-			int toRead = std::min(ramSize - (writePtr - readPtr), sizeof(buffer));
-			int length = src->read(buffer, toRead);
-			if (length > 0) {
+    // Check if the buffer isn't empty, otherwise we try to fill completely
+    if (!filled) {
+        cb.st(999, PSTR("Filling buffer..."));
+        uint8_t buffer[256];
+        writePtr = 0;
+        readPtr = 0;
+        // Fill up completely before returning any data at all
+        do {
+            int toRead = std::min(ramSize - (writePtr - readPtr), sizeof(buffer));
+            int length = src->read(buffer, toRead);
+            if (length > 0) {
 #ifdef FAKERAM
-				for (size_t i=0; i<length; i++) fakeRAM[(i+writePtr)%ramSize] = buffer[i];
+                for (size_t i=0; i<length; i++) fakeRAM[(i+writePtr)%ramSize] = buffer[i];
 #else
-				ram.writeBytes(writePtr % ramSize, buffer, length);
+                ram.writeBytes(writePtr % ramSize, buffer, length);
 #endif
-				writePtr += length;
-			} else {
-				// EOF, break out of read loop
-				break;
-			}
-		} while ((writePtr - readPtr) < ramSize);
-		filled = true;
-		cb.st(999, PSTR("Buffer filled..."));
-	}
+                writePtr += length;
+            } else {
+                // EOF, break out of read loop
+                break;
+            }
+        } while ((writePtr - readPtr) < ramSize);
+        filled = true;
+        cb.st(999, PSTR("Buffer filled..."));
+    }
 
-	// Read up to the entire buffer from RAM
-	uint32_t toReadFromBuffer = std::min(len, writePtr - readPtr);
-	uint8_t *ptr = reinterpret_cast<uint8_t*>(data);
-	if (toReadFromBuffer > 0) {
+    // Read up to the entire buffer from RAM
+    uint32_t toReadFromBuffer = std::min(len, writePtr - readPtr);
+    uint8_t *ptr = reinterpret_cast<uint8_t*>(data);
+    if (toReadFromBuffer > 0) {
 #ifdef FAKERAM
-		for (size_t i=0; i<toReadFromBuffer; i++) ptr[i] = fakeRAM[(i+readPtr)%ramSize];
+        for (size_t i=0; i<toReadFromBuffer; i++) ptr[i] = fakeRAM[(i+readPtr)%ramSize];
 #else
-		ram.readBytes(readPtr % ramSize, ptr, toReadFromBuffer);
+        ram.readBytes(readPtr % ramSize, ptr, toReadFromBuffer);
 #endif
-		readPtr += toReadFromBuffer;
-		ptr += toReadFromBuffer;
-		bytes += toReadFromBuffer;
-		len -= toReadFromBuffer;
-	}
+        readPtr += toReadFromBuffer;
+        ptr += toReadFromBuffer;
+        bytes += toReadFromBuffer;
+        len -= toReadFromBuffer;
+    }
 
-	// If len>0 there is no data left in buffer and we try to read more directly from source.
-	// Then, we trigger a complete buffer refill
-	if (len) {
-		bytes += src->read(data, len);
-		filled = false;
-	}
-	return bytes;
+    // If len>0 there is no data left in buffer and we try to read more directly from source.
+    // Then, we trigger a complete buffer refill
+    if (len) {
+        bytes += src->read(data, len);
+        filled = false;
+    }
+    return bytes;
 }
 
 void AudioFileSourceSPIRAMBuffer::fill()
 {
-	// Make sure the buffer is pre-filled before make partial fill.
-	if (!filled) return;
+    // Make sure the buffer is pre-filled before make partial fill.
+    if (!filled) return;
 
-	for (auto i=0; i<5; i++) {
-		// Make sure there is at least buffer size free in RAM
-		uint8_t buffer[128];
-		if ((ramSize - (writePtr - readPtr)) < sizeof(buffer)) {
-			return;
-		}
+    for (auto i=0; i<5; i++) {
+        // Make sure there is at least buffer size free in RAM
+        uint8_t buffer[128];
+        if ((ramSize - (writePtr - readPtr)) < sizeof(buffer)) {
+            return;
+        }
 
-		int cnt = src->readNonBlock(buffer, sizeof(buffer));
-		if (cnt) {
+        int cnt = src->readNonBlock(buffer, sizeof(buffer));
+        if (cnt) {
 #ifdef FAKERAM
-			for (size_t i=0; i<cnt; i++) fakeRAM[(i+writePtr)%ramSize] = buffer[i];
+            for (size_t i=0; i<cnt; i++) fakeRAM[(i+writePtr)%ramSize] = buffer[i];
 #else
-			ram.writeBytes(writePtr % ramSize, buffer, cnt);
+            ram.writeBytes(writePtr % ramSize, buffer, cnt);
 #endif
-			writePtr += cnt;
-		}
-	}
+            writePtr += cnt;
+        }
+    }
 }
 
 bool AudioFileSourceSPIRAMBuffer::loop()
 {
-	static uint32_t last = 0;
-	if (!src->loop()) return false;
-	fill();
-	if ((ESP.getCycleCount() - last) > microsecondsToClockCycles(1000000)) {
-		last = ESP.getCycleCount();
-			char str[65];
-			memset(str, '#', 64);
-			str[64] = 0;
-			str[((writePtr - readPtr) * 64)/ramSize] = 0;
-			cb.st(((writePtr - readPtr) * 100)/ramSize, str);
-	}
-	return true;
+    static uint32_t last = 0;
+    if (!src->loop()) return false;
+    fill();
+    if ((ESP.getCycleCount() - last) > microsecondsToClockCycles(1000000)) {
+        last = ESP.getCycleCount();
+            char str[65];
+            memset(str, '#', 64);
+            str[64] = 0;
+            str[((writePtr - readPtr) * 64)/ramSize] = 0;
+            cb.st(((writePtr - readPtr) * 100)/ramSize, str);
+    }
+    return true;
 }

--- a/src/AudioFileSourceSPIRAMBuffer.h
+++ b/src/AudioFileSourceSPIRAMBuffer.h
@@ -55,13 +55,11 @@ class AudioFileSourceSPIRAMBuffer : public AudioFileSource
     size_t ramSize;
     size_t writePtr;
     size_t readPtr;
-	bool filled;
-	
+    bool filled;
+
 #ifdef FAKERAM
-	char fakeRAM[2048];
+    char fakeRAM[2048];
 #endif
 };
 
-
 #endif
-


### PR DESCRIPTION
Seems like VSCODE and others try and compile all files in a directory,
even if they aren't used.  Because the spiram-fast had ESP8266-only
registers, it caused an error when attempting to build anything for the
ESP32.

Update by writing a new SPI class based version of the spiram-fast class
(tested on the ESP8266) which uses the SPI wrapper class.

Fixes #253

@Maigre, can you give this a test and make sure it fixes the issue?  Thx!