### PR TITLE
Redo the last packet handling of the MP3 decoder

### DIFF
--- a/src/AudioGeneratorMP3.h
+++ b/src/AudioGeneratorMP3.h
@@ -43,9 +43,9 @@ class AudioGeneratorMP3 : public AudioGenerator
     const int buffLen = 0x600; // Slightly larger than largest MP3 frame
     unsigned char *buff;
     int lastReadPos;
+    int lastBuffLen;
     unsigned int lastRate;
     int lastChannels;
-    bool finishing;
     
     // Decoding bits
     bool madInitted;


### PR DESCRIPTION
Keep track of how many values are actually good in the buffer (before it
was always guaranteed to be the full size) and when EOF is detected,
only shift out valid, good bytes, and return STOP when the unused bytes
are 0 or unchanged from the last pass.

Fixes #265