### PR TITLE
added missing DMA buffer flush, see issue #270 for details

### DIFF
--- a/src/AudioOutput.h
+++ b/src/AudioOutput.h
@@ -45,6 +45,7 @@ class AudioOutput
       return count;
     }
     virtual bool stop() { return false; }
+    virtual void flush() { return; }
     virtual bool loop() { return true; }
 
   public:

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -34,6 +34,7 @@ class AudioOutputI2S : public AudioOutput
     virtual bool SetChannels(int channels) override;
     virtual bool begin() override;
     virtual bool ConsumeSample(int16_t sample[2]) override;
+    virtual void flush() override;
     virtual bool stop() override;
     
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
@@ -47,6 +48,7 @@ class AudioOutputI2S : public AudioOutput
     int output_mode;
     bool mono;
     bool i2sOn;
+    int dma_buf_count;
     // We can restore the old values and free up these pins when in NoDAC mode
     uint32_t orig_bck;
     uint32_t orig_ws;


### PR DESCRIPTION
Thanks to @ikostoski tipps I created my first C++ PR :-)

* added `flush()` to `AudioOutput.h`
* implemented the described DMA consume loop
* tested it with my sample project (worked like a charm)

I did not add the call `flush()` to the `stop()` method, because sometimes you just want to stop ;-). In other words: You have to call explicitly `flush()` in order to push out the last wave bits in to the DAC.