### PR TITLE
Fix factor-of-2-off MIDI velocity parsing

### DIFF
--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -359,7 +359,7 @@ void AudioGeneratorMIDI::PrepareMIDI(AudioFileSource *src)
   earliest_time = 0;
 }
 
-// Parses the note on/offs ujntil we are ready to render some more samples.  Then return the
+// Parses the note on/offs until we are ready to render some more samples.  Then return the
 // total number of samples to render before we need to be called again
 int AudioGeneratorMIDI::PlayMIDI()
 {
@@ -472,7 +472,7 @@ int AudioGeneratorMIDI::PlayMIDI()
         if (tg->instrument != midi_chan_instrument[trk->chan]) {    /* new instrument for this generator */
           tg->instrument = midi_chan_instrument[trk->chan];
         }
-        tsf_note_on (g_tsf, tg->instrument, tg->note, trk->velocity / 256.0);
+        tsf_note_on (g_tsf, tg->instrument, tg->note, trk->velocity / 127.0); // velocity = 0...127
       } else {
         ++notes_skipped;
       }


### PR DESCRIPTION
Velocity in the MIDI format goes from 1...127, so scale the voulme of
the note generater by /128 instead of /256.   Increases volume of all
notes by 2x linratly (3dB).

Found by Marc Madaule