### PR TITLE
Fix missed merge in MIDI notegen

### DIFF
--- a/src/libtinysoundfont/tsf.h
+++ b/src/libtinysoundfont/tsf.h
@@ -1444,7 +1444,7 @@ static void tsf_voice_render_fast(tsf* f, struct tsf_voice* v, short* outputBuff
   struct tsf_voice_lowpass tmpLowpass = v->lowpass;
 
   TSF_BOOL dynamicLowpass = (region->modLfoToFilterFc || region->modEnvToFilterFc);
-  float tmpSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
+  float tmpSampleRate = f->outSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
 
   TSF_BOOL dynamicPitchRatio = (region->modLfoToPitch || region->modEnvToPitch || region->vibLfoToPitch);
   //double pitchRatio;
@@ -1454,8 +1454,8 @@ static void tsf_voice_render_fast(tsf* f, struct tsf_voice* v, short* outputBuff
   TSF_BOOL dynamicGain = (region->modLfoToVolume != 0);
   float noteGain, tmpModLfoToVolume;
 
-  if (dynamicLowpass) tmpSampleRate = f->outSampleRate, tmpInitialFilterFc = (float)region->initialFilterFc, tmpModLfoToFilterFc = (float)region->modLfoToFilterFc, tmpModEnvToFilterFc = (float)region->modEnvToFilterFc;
-  else tmpSampleRate = 0, tmpInitialFilterFc = 0, tmpModLfoToFilterFc = 0, tmpModEnvToFilterFc = 0;
+  if (dynamicLowpass) tmpInitialFilterFc = (float)region->initialFilterFc, tmpModLfoToFilterFc = (float)region->modLfoToFilterFc, tmpModEnvToFilterFc = (float)region->modEnvToFilterFc;
+  else tmpInitialFilterFc = 0, tmpModLfoToFilterFc = 0, tmpModEnvToFilterFc = 0;
 
   if (dynamicPitchRatio) pitchRatioF32P32 = 0, tmpModLfoToPitch = (float)region->modLfoToPitch, tmpVibLfoToPitch = (float)region->vibLfoToPitch, tmpModEnvToPitch = (float)region->modEnvToPitch;
   else {


### PR DESCRIPTION
Patch 21c07c0bcd702e7adf3db349ac926914b98d17ce was applied to the TSF's
original code, but not to the fixed-point generator used by the ESP8266.
Apply it to the FP unit as well.

Spotted by Marc Madaule