### PR TITLE
Fix AAC mono decode

### DIFF
--- a/src/AudioGeneratorAAC.cpp
+++ b/src/AudioGeneratorAAC.cpp
@@ -144,8 +144,13 @@ bool AudioGeneratorAAC::loop()
 
   // If we've got data, try and pump it out...
   while (validSamples) {
-    lastSample[0] = outSample[curSample*2];
-    lastSample[1] = outSample[curSample*2 + 1];
+    if (lastChannels == 1) {
+       lastSample[0] = outSample[curSample];
+       lastSample[1] = outSample[curSample];
+    } else {
+      lastSample[0] = outSample[curSample*2];
+      lastSample[1] = outSample[curSample*2 + 1];
+    }
     if (!output->ConsumeSample(lastSample)) goto done; // Can't send, but no error detected
     validSamples--;
     curSample++;


### PR DESCRIPTION
As noted by Marc Madaule (thanks!), the mono AAC decode was not
functioning properly.  Adjust the output stuff loop to fix.