### PR TITLE
Fixes when seeking in an MP3 file

### DIFF
--- a/src/AudioGenerator.h
+++ b/src/AudioGenerator.h
@@ -35,6 +35,7 @@ class AudioGenerator
     virtual bool loop() { return false; };
     virtual bool stop() { return false; };
     virtual bool isRunning() { return false;};
+    virtual void desync () { };
 
   public:
     virtual bool RegisterMetadataCB(AudioStatus::metadataCBFn fn, void *data) { return cb.RegisterMetadataCB(fn, data); }

--- a/src/AudioGeneratorMP3.cpp
+++ b/src/AudioGeneratorMP3.cpp
@@ -224,7 +224,6 @@ retry:
         return false;
       }
 
-      static int unrecoverable = 0;
       if (!DecodeNextFrame()) {
         if (stream->error == MAD_ERROR_BUFLEN) {
           // randomly seeking can lead to endless

--- a/src/AudioGeneratorMP3.cpp
+++ b/src/AudioGeneratorMP3.cpp
@@ -229,7 +229,6 @@ retry:
           // randomly seeking can lead to endless
           // and unrecoverable "MAD_ERROR_BUFLEN" loop
           audioLogger->printf_P(PSTR("MP3:ERROR_BUFLEN %d\n"), unrecoverable);
-          Serial.flush();
           if (++unrecoverable >= 3) {
             unrecoverable = 0;
             return (running = false);

--- a/src/AudioGeneratorMP3.h
+++ b/src/AudioGeneratorMP3.h
@@ -30,17 +30,30 @@ class AudioGeneratorMP3 : public AudioGenerator
   public:
     AudioGeneratorMP3();
     AudioGeneratorMP3(void *preallocateSpace, int preallocateSize);
+    AudioGeneratorMP3(void *buff, int buffSize, void *stream, int streamSize, void *frame, int frameSize, void *synth, int synthSize);
     virtual ~AudioGeneratorMP3() override;
     virtual bool begin(AudioFileSource *source, AudioOutput *output) override;
     virtual bool loop() override;
     virtual bool stop() override;
     virtual bool isRunning() override;
     
-  protected:   
-    void *preallocateSpace;
-    int preallocateSize;
+    static constexpr int preAllocSize () { return preAllocBuffSize() + preAllocStreamSize() + preAllocFrameSize() + preAllocSynthSize(); }
+    static constexpr int preAllocBuffSize () { return ((buffLen + 7) & ~7); }
+    static constexpr int preAllocStreamSize () { return ((sizeof(struct mad_stream) + 7) & ~7); }
+    static constexpr int preAllocFrameSize () { return (sizeof(struct mad_frame) + 7) & ~7; }
+    static constexpr int preAllocSynthSize () { return (sizeof(struct mad_synth) + 7) & ~7; }
 
-    const int buffLen = 0x600; // Slightly larger than largest MP3 frame
+  protected:   
+    void *preallocateSpace = nullptr;
+    int preallocateSize = 0;
+    void *preallocateStreamSpace = nullptr;
+    int preallocateStreamSize = 0;
+    void *preallocateFrameSpace = nullptr;
+    int preallocateFrameSize = 0;
+    void *preallocateSynthSpace = nullptr;
+    int preallocateSynthSize = 0;
+
+    static constexpr int buffLen = 0x600; // Slightly larger than largest MP3 frame
     unsigned char *buff;
     int lastReadPos;
     int lastBuffLen;

--- a/src/AudioGeneratorMP3.h
+++ b/src/AudioGeneratorMP3.h
@@ -36,7 +36,8 @@ class AudioGeneratorMP3 : public AudioGenerator
     virtual bool loop() override;
     virtual bool stop() override;
     virtual bool isRunning() override;
-    
+    virtual void desync () override;
+
     static constexpr int preAllocSize () { return preAllocBuffSize() + preAllocStreamSize() + preAllocFrameSize() + preAllocSynthSize(); }
     static constexpr int preAllocBuffSize () { return ((buffLen + 7) & ~7); }
     static constexpr int preAllocStreamSize () { return ((sizeof(struct mad_stream) + 7) & ~7); }

--- a/src/AudioGeneratorMP3.h
+++ b/src/AudioGeneratorMP3.h
@@ -76,6 +76,8 @@ class AudioGeneratorMP3 : public AudioGenerator
     bool DecodeNextFrame();
     bool GetOneSample(int16_t sample[2]);
 
+  private:
+    int unrecoverable = 0;
 };
 
 #endif


### PR DESCRIPTION
This PR:
- add desync() for user to call when randomly seeking in the input file
- try to fix corner cases leading to exceptions when seeking (`memmove(size=-1)`)

This PR also adds a new constructor for preallocated structures, intended to be tried with IRAM memory area.
That part can be pulled out and made into another PR.
