### PR TITLE
Fix the dependencies in the library's PIO config

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,7 +17,10 @@
     "version": "1.5.1",
     "homepage": "https://github.com/earlephilhower/ESP8266Audio",
     "dependencies": {
-        "SPI": "1.0"
+        "SPI": "1.0",
+        "SPIFFS": "1.0",
+        "HTTPClient": "1.0",
+        "WiFiClientSecure": "1.0"
     },
     "frameworks": "Arduino",
     "examples": [


### PR DESCRIPTION
PlatformIO requires these dependencies to be explicitly mentioned. Please check the version numbers of the libraries specified are correct. However, v1.0 for each allows for successful builds. Thanks!