### PR TITLE
Modify AudioOutputI2S to initialize i2s during begin

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -35,113 +35,77 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
     output_mode = EXTERNAL_I2S;
   }
   this->output_mode = output_mode;
-#ifdef ESP32
-  if (!i2sOn) {
-    if (use_apll == APLL_AUTO) {
-      // don't use audio pll on buggy rev0 chips
-      use_apll = APLL_DISABLE;
-      esp_chip_info_t out_info;
-      esp_chip_info(&out_info);
-      if(out_info.revision > 0) {
-        use_apll = APLL_ENABLE;
-      }
-    }
+  this->use_apll = use_apll;
 
-    i2s_mode_t mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
-    if (output_mode == INTERNAL_DAC) {
-      mode = (i2s_mode_t)(mode | I2S_MODE_DAC_BUILT_IN);
-    } else if (output_mode == INTERNAL_PDM) {
-      mode = (i2s_mode_t)(mode | I2S_MODE_PDM);
-    }
-
-    i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
-    if (output_mode == INTERNAL_DAC) {
-      comm_fmt = (i2s_comm_format_t)I2S_COMM_FORMAT_I2S_MSB;
-    }
-
-    i2s_config_t i2s_config_dac = {
-      .mode = mode,
-      .sample_rate = 44100,
-      .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
-      .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
-      .communication_format = comm_fmt,
-      .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // lowest interrupt priority
-      .dma_buf_count = dma_buf_count,
-      .dma_buf_len = 64,
-      .use_apll = use_apll // Use audio PLL
-    };
-    audioLogger->printf("+%d %p\n", portNo, &i2s_config_dac);
-    if (i2s_driver_install((i2s_port_t)portNo, &i2s_config_dac, 0, NULL) != ESP_OK) {
-      audioLogger->println("ERROR: Unable to install I2S drives\n");
-    }
-    if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM) {
-      i2s_set_pin((i2s_port_t)portNo, NULL);
-      i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
-    } else {
-      SetPinout(26, 25, 22);
-    }
-    i2s_zero_dma_buffer((i2s_port_t)portNo);
-  } 
-#else
-  (void) dma_buf_count;
-  (void) use_apll;
-  if (!i2sOn) {
-    orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
-    orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
-    i2s_begin();
-  }
-#endif
-  i2sOn = true;
+  //set defaults
   mono = false;
   bps = 16;
   channels = 2;
+  hertz = 44100;
+  bclkPin = 26;
+  wclkPin = 25;
+  doutPin = 22;
   SetGain(1.0);
-  SetRate(44100); // Default
 }
 
 AudioOutputI2S::~AudioOutputI2S()
 {
-#ifdef ESP32
-  if (i2sOn) {
-    audioLogger->printf("UNINSTALL I2S\n");
-    i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
-  }
-#else
-  if (i2sOn) i2s_end();
-#endif
+  #ifdef ESP32
+    if (i2sOn) {
+      audioLogger->printf("UNINSTALL I2S\n");
+      i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
+    }
+  #else
+    if (i2sOn)
+      i2s_end();
+  #endif
   i2sOn = false;
 }
 
 bool AudioOutputI2S::SetPinout(int bclk, int wclk, int dout)
 {
-#ifdef ESP32
-  if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM) return false; // Not allowed
+  bclkPin = bclk;
+  wclkPin = wclk;
+  doutPin = dout;
+  if (i2sOn)
+    return SetPinout();
 
-  i2s_pin_config_t pins = {
-    .bck_io_num = bclk,
-    .ws_io_num = wclk,
-    .data_out_num = dout,
-    .data_in_num = I2S_PIN_NO_CHANGE
-  };
-  i2s_set_pin((i2s_port_t)portNo, &pins);
   return true;
-#else
-  (void) bclk;
-  (void) wclk;
-  (void) dout;
-  return false;
-#endif
+}
+
+bool AudioOutputI2S::SetPinout()
+{
+  #ifdef ESP32
+    if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM)
+      return false; // Not allowed
+
+    i2s_pin_config_t pins = {
+        .bck_io_num = bclkPin,
+        .ws_io_num = wclkPin,
+        .data_out_num = doutPin,
+        .data_in_num = I2S_PIN_NO_CHANGE};
+    i2s_set_pin((i2s_port_t)portNo, &pins);
+    return true;
+  #else
+    (void)bclk;
+    (void)wclk;
+    (void)dout;
+    return false;
+  #endif
 }
 
 bool AudioOutputI2S::SetRate(int hz)
 {
   // TODO - have a list of allowable rates from constructor, check them
   this->hertz = hz;
-#ifdef ESP32
-  i2s_set_sample_rates((i2s_port_t)portNo, AdjustI2SRate(hz)); 
-#else
-  i2s_set_rate(AdjustI2SRate(hz));
-#endif
+  if (i2sOn)
+  {
+  #ifdef ESP32
+      i2s_set_sample_rates((i2s_port_t)portNo, AdjustI2SRate(hz));
+  #else
+      i2s_set_rate(AdjustI2SRate(hz));
+  #endif
+  }
   return true;
 }
 
@@ -167,11 +131,86 @@ bool AudioOutputI2S::SetOutputModeMono(bool mono)
 
 bool AudioOutputI2S::begin()
 {
+  #ifdef ESP32
+    if (!i2sOn)
+    {
+      if (use_apll == APLL_AUTO)
+      {
+        // don't use audio pll on buggy rev0 chips
+        use_apll = APLL_DISABLE;
+        esp_chip_info_t out_info;
+        esp_chip_info(&out_info);
+        if (out_info.revision > 0)
+        {
+          use_apll = APLL_ENABLE;
+        }
+      }
+
+      i2s_mode_t mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
+      if (output_mode == INTERNAL_DAC)
+      {
+        mode = (i2s_mode_t)(mode | I2S_MODE_DAC_BUILT_IN);
+      }
+      else if (output_mode == INTERNAL_PDM)
+      {
+        mode = (i2s_mode_t)(mode | I2S_MODE_PDM);
+      }
+
+      i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
+      if (output_mode == INTERNAL_DAC)
+      {
+        comm_fmt = (i2s_comm_format_t)I2S_COMM_FORMAT_I2S_MSB;
+      }
+
+      i2s_config_t i2s_config_dac = {
+          .mode = mode,
+          .sample_rate = 44100,
+          .bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT,
+          .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT,
+          .communication_format = comm_fmt,
+          .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // lowest interrupt priority
+          .dma_buf_count = dma_buf_count,
+          .dma_buf_len = 64,
+          .use_apll = use_apll // Use audio PLL
+      };
+      audioLogger->printf("+%d %p\n", portNo, &i2s_config_dac);
+      if (i2s_driver_install((i2s_port_t)portNo, &i2s_config_dac, 0, NULL) != ESP_OK)
+      {
+        audioLogger->println("ERROR: Unable to install I2S drives\n");
+      }
+      if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM)
+      {
+        i2s_set_pin((i2s_port_t)portNo, NULL);
+        i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
+      }
+      else
+      {
+        SetPinout();
+      }
+      i2s_zero_dma_buffer((i2s_port_t)portNo);
+    }
+  #else
+    (void)dma_buf_count;
+    (void)use_apll;
+    if (!i2sOn)
+    {
+      orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
+      orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
+      i2s_begin();
+    }
+  #endif
+  i2sOn = true;
+  SetRate(hertz); // Default
   return true;
 }
 
 bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
 {
+
+  //return if we haven't called ::begin yet
+  if (i2sOn)
+    return false;
+
   int16_t ms[2];
 
   ms[0] = sample[0];
@@ -183,41 +222,48 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
     int32_t ttl = ms[LEFTCHANNEL] + ms[RIGHTCHANNEL];
     ms[LEFTCHANNEL] = ms[RIGHTCHANNEL] = (ttl>>1) & 0xffff;
   }
-#ifdef ESP32
-  uint32_t s32;
-  if (output_mode == INTERNAL_DAC) {
-    int16_t l = Amplify(ms[LEFTCHANNEL]) + 0x8000;
-    int16_t r = Amplify(ms[RIGHTCHANNEL]) + 0x8000;
-    s32 = (r<<16) | (l&0xffff);
-  } else {
-    s32 = ((Amplify(ms[RIGHTCHANNEL]))<<16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
-  }
-  return i2s_write_bytes((i2s_port_t)portNo, (const char*)&s32, sizeof(uint32_t), 0);
-#else
-  uint32_t s32 = ((Amplify(ms[RIGHTCHANNEL]))<<16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
-  return i2s_write_sample_nb(s32); // If we can't store it, return false.  OTW true
-#endif
+  #ifdef ESP32
+    uint32_t s32;
+    if (output_mode == INTERNAL_DAC)
+    {
+      int16_t l = Amplify(ms[LEFTCHANNEL]) + 0x8000;
+      int16_t r = Amplify(ms[RIGHTCHANNEL]) + 0x8000;
+      s32 = (r << 16) | (l & 0xffff);
+    }
+    else
+    {
+      s32 = ((Amplify(ms[RIGHTCHANNEL])) << 16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
+    }
+    return i2s_write_bytes((i2s_port_t)portNo, (const char *)&s32, sizeof(uint32_t), 0);
+  #else
+    uint32_t s32 = ((Amplify(ms[RIGHTCHANNEL])) << 16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
+    return i2s_write_sample_nb(s32); // If we can't store it, return false.  OTW true
+  #endif
 }
 
-void AudioOutputI2S::flush() {
-#ifdef ESP32
-  // makes sure that all stored DMA samples are consumed / played
-  int buffersize = 64 * this->dma_buf_count;
-  int16_t samples[2] = {0x0,0x0};
-  for (int i=0;i<buffersize; i++) {
-    while (!ConsumeSample(samples)) {
-      delay(10);
+void AudioOutputI2S::flush()
+{
+  #ifdef ESP32
+    // makes sure that all stored DMA samples are consumed / played
+    int buffersize = 64 * this->dma_buf_count;
+    int16_t samples[2] = {0x0, 0x0};
+    for (int i = 0; i < buffersize; i++)
+    {
+      while (!ConsumeSample(samples))
+      {
+        delay(10);
+      }
     }
-  }
-#endif
+  #endif
 }
 
 bool AudioOutputI2S::stop()
 {
-#ifdef ESP32
-  i2s_zero_dma_buffer((i2s_port_t)portNo);
-#endif
+  //return if we haven't called ::begin yet
+  if (i2sOn)
+    return false;
+  #ifdef ESP32
+    i2s_zero_dma_buffer((i2s_port_t)portNo);
+  #endif
   return true;
 }
-
-

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -87,9 +87,9 @@ bool AudioOutputI2S::SetPinout()
     i2s_set_pin((i2s_port_t)portNo, &pins);
     return true;
   #else
-    (void)bclk;
-    (void)wclk;
-    (void)dout;
+    (void)bclkPin;
+    (void)wclkPin;
+    (void)doutPin;
     return false;
   #endif
 }
@@ -261,7 +261,7 @@ bool AudioOutputI2S::stop()
 {
   if (!i2sOn)
     return false;
-    
+
   #ifdef ESP32
     i2s_zero_dma_buffer((i2s_port_t)portNo);
   #endif

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -208,7 +208,7 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
 {
 
   //return if we haven't called ::begin yet
-  if (i2sOn)
+  if (!i2sOn)
     return false;
 
   int16_t ms[2];
@@ -259,9 +259,9 @@ void AudioOutputI2S::flush()
 
 bool AudioOutputI2S::stop()
 {
-  //return if we haven't called ::begin yet
-  if (i2sOn)
+  if (!i2sOn)
     return false;
+    
   #ifdef ESP32
     i2s_zero_dma_buffer((i2s_port_t)portNo);
   #endif

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -43,15 +43,21 @@ class AudioOutputI2S : public AudioOutput
     enum : int { EXTERNAL_I2S = 0, INTERNAL_DAC = 1, INTERNAL_PDM = 2 };
 
   protected:
+    bool SetPinout();
     virtual int AdjustI2SRate(int hz) { return hz; }
     uint8_t portNo;
     int output_mode;
     bool mono;
     bool i2sOn;
     int dma_buf_count;
+    int use_apll;
     // We can restore the old values and free up these pins when in NoDAC mode
     uint32_t orig_bck;
     uint32_t orig_ws;
+    
+    uint8_t bclkPin;
+    uint8_t wclkPin;
+    uint8_t doutPin;
 };
 
 #endif


### PR DESCRIPTION
Moved most of the constructor login into the begin method except for setting up variables/defaults. Now when you set any variables before calling begin it stores those variables until begin is called which sets i2sOn to true. Then those methods work like they previously did.

Addressing Issues: #330 