### PR TITLE
Modified AudioFileSourceFS.h to add resolution operator on items defi…

### DIFF
--- a/src/AudioFileSourceFS.h
+++ b/src/AudioFileSourceFS.h
@@ -29,8 +29,8 @@
 class AudioFileSourceFS : public AudioFileSource
 {
   public:
-    AudioFileSourceFS(FS &fs) { filesystem = &fs; }
-    AudioFileSourceFS(FS &fs, const char *filename);
+    AudioFileSourceFS(fs::FS &fs) { filesystem = &fs; }
+    AudioFileSourceFS(fs::FS &fs, const char *filename);
     virtual ~AudioFileSourceFS() override;
     
     virtual bool open(const char *filename) override;
@@ -42,8 +42,8 @@ class AudioFileSourceFS : public AudioFileSource
     virtual uint32_t getPos() override { if (!f) return 0; else return f.position(); };
 
   private:
-    FS *filesystem;
-    File f;
+    fs::FS *filesystem;
+    fs::File f;
 };
 
 


### PR DESCRIPTION
Hi there !

I've started to work with the library a few days ago, building a music player with esp32.

I've encountered an error when using the AudioFileSourceFS class, because FS.h defines both File and FS classes into a namespace. I thus added the resolution operator for this namespace when nedded.

Thank you