### PR TITLE
tags framesize endless loop

### DIFF
--- a/src/AudioFileSourceFS.h
+++ b/src/AudioFileSourceFS.h
@@ -29,8 +29,8 @@
 class AudioFileSourceFS : public AudioFileSource
 {
   public:
-    AudioFileSourceFS(FS &fs) { filesystem = &fs; }
-    AudioFileSourceFS(FS &fs, const char *filename);
+    AudioFileSourceFS(fs::FS &fs) { filesystem = &fs; }
+    AudioFileSourceFS(fs::FS &fs, const char *filename);
     virtual ~AudioFileSourceFS() override;
     
     virtual bool open(const char *filename) override;
@@ -42,8 +42,8 @@ class AudioFileSourceFS : public AudioFileSource
     virtual uint32_t getPos() override { if (!f) return 0; else return f.position(); };
 
   private:
-    FS *filesystem;
-    File f;
+    fs::FS *filesystem;
+    fs::File f;
 };
 
 

--- a/src/AudioFileSourceID3.cpp
+++ b/src/AudioFileSourceID3.cpp
@@ -143,6 +143,7 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
   if (ret<10) return ret;
 
   if ((buff[0]!='I') || (buff[1]!='D') || (buff[2]!='3') || (buff[3]>0x04) || (buff[3]<0x02) || (buff[4]!=0)) {
+    cb.md("eof", false, "id3");
     return 10 + src->read(buff+10, len-10);
   }
 
@@ -212,7 +213,7 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
 
       // Read the value and send to callback
       char value[64];
-      uint16_t i;
+      uint32_t i;
       bool isUnicode = (id3.getByte()==1) ? true : false;
       for (i=0; i<framesize-1; i++) {
         if (i<sizeof(value)-1) value[i] = id3.getByte();
@@ -231,9 +232,23 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
       } else if ( (frameid[0]=='T' && frameid[1]=='Y' && frameid[2]=='E' && frameid[3] == 'R') ||
                   (frameid[0]=='T' && frameid[1]=='Y' && frameid[2]=='E' && rev==2) ) {
         cb.md("Year", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='R' && frameid[2]=='C' && frameid[3] == 'K') ||
+                  (frameid[0]=='T' && frameid[1]=='R' && frameid[2]=='K' && rev==2) ) {
+        cb.md("track", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='P' && frameid[2]=='O' && frameid[3] == 'S') ||
+                  (frameid[0]=='T' && frameid[1]=='P' && frameid[2]=='A' && rev==2) ) {
+        cb.md("Set", isUnicode, value);
+      } else if ( (frameid[0]=='P' && frameid[1]=='O' && frameid[2]=='P' && frameid[3] == 'M') ||
+                  (frameid[0]=='P' && frameid[1]=='O' && frameid[2]=='P' && rev==2) ) {
+        cb.md("Popularimeter", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='C' && frameid[2]=='M' && frameid[3] == 'P') ) {
+        cb.md("Compilation", isUnicode, value);
       }
     }
   } while (!id3.eof());
+
+  // use callback function to signal end of tags and beginning of content.
+  cb.md("eof", false, "id3");
 
   // All ID3 processing done, return to main caller
   return src->read(data, len);


### PR DESCRIPTION
I've run into a problem while parsing tags in mp3 files with embedded images (`APIC` frames), with my program freezing.
It appears that the `for loop` which populate the `value` buffer has an `int16_t` as a counter, thus overflowing when frame size is above 65535 bytes. I've changed it to an `int32_t`.

Besides, I needed some other tags to be extracted for my projects, I've thus added the following ones : 
`TRCK / TRK`track number (+ total tracks)
`TPOS / TPA` part of a set (+ total set) _i.e._ if the album has several discs.
`POPM / POP` popularimeter, _aka_ rating.
`TCMP` "part of a compilation". It's not clear if this one is an off-standard added by iTunes, or if it's included in ID3v4