### PR TITLE
Fixes for the ULP driver

### DIFF
--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -205,11 +205,13 @@ bool AudioOutputULP::ConsumeSample(int16_t sample[2])
   if(waitingOddSample){ // always true for stereo because samples are consumed in pairs
     if(lastFilledWord != currentWord) // accept sample if writing index lastFilledWord has not reached index of output sample
     {
-      unsigned int w = ms[0];
+      unsigned int w;
       if(stereoOutput){
+        w = ms[0];
         w |= ms[1] << 8;
       } else {
-        w |= bufferedOddSample << 8;
+        w = bufferedOddSample;
+        w |= ms[0] << 8;
         bufferedOddSample = 128;
         waitingOddSample = false;
       }

--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -68,8 +68,8 @@ bool AudioOutputULP::begin()
   int retAddress1 = 9;
   int retAddress2 = 14;
 
-  int loopCycles = 120;
-  int loopHalfCycles1 = 76;
+  int loopCycles = 134;
+  int loopHalfCycles1 = 90;
   int loopHalfCycles2 = 44;
   
   Serial.print("Real RTC clock: ");
@@ -119,10 +119,14 @@ bool AudioOutputULP::begin()
     //jump to the dac opcode
     I_BXR(R2), // 4
     //here we get back from writing the second sample
+    //load 0x8080 as sample
+    I_MOVI(R1, 0x8080), // 6
+    //write 0x8080 in the sample buffer
+    I_ST(R1, R0, indexAddress), // 8
     //increment the sample index
     I_ADDI(R0, R0, 1), // 6
     //if reached end of the buffer, jump relative to index reset
-    I_BGE(-14, totalSampleWords), // 4
+    I_BGE(-16, totalSampleWords), // 4
     //wait to get the right sample rate (2 cycles more to compensate the index reset)
     I_DELAY((unsigned int)dt + 2), // 8 + dt
     //if not, jump absolute to where index is written to memory

--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -2,8 +2,6 @@
   AudioOutputULP
   Outputs to ESP32 DAC through the ULP, freeing I2S for other uses
   
-  v 0.0.1 (2020-10-01)
-  
   Copyright (C) 2020  Martin Laclaustra, based on bitluni's code
 
   This program is free software: you can redistribute it and/or modify

--- a/src/AudioOutputULP.h
+++ b/src/AudioOutputULP.h
@@ -18,8 +18,16 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Instructions:
+// AudioOutputULP out = new AudioOutputULP(); // stereo
 // Connect left channel on pin 25
 // Connect right channel on pin 26
+// OR
+// Connect mono channel on either of them (stereo samples are downmixed)
+// AudioOutputULP out = new AudioOutputULP(1); // mono, only DAC 1
+// OR
+// AudioOutputULP out = new AudioOutputULP(2); // mono, only DAC 2
+
 
 #ifndef _AUDIOOUTPUTULP_H
 #define _AUDIOOUTPUTULP_H

--- a/src/AudioOutputULP.h
+++ b/src/AudioOutputULP.h
@@ -2,8 +2,6 @@
   AudioOutputULP
   Outputs to ESP32 DAC through the ULP, freeing I2S for other uses
   
-  v 0.0.1 (2020-10-01)
-  
   Copyright (C) 2020  Martin Laclaustra, based on bitluni's code
 
   This program is free software: you can redistribute it and/or modify

--- a/src/AudioOutputULP.h
+++ b/src/AudioOutputULP.h
@@ -51,7 +51,7 @@ class AudioOutputULP : public AudioOutput
     bool waitingOddSample = true; // must be set to false for mono output
     int activeDACs = 3; // 1:DAC1; 2:DAC2; 3:both;
     bool stereoOutput = true;
-    const int opcodeCount = 18;
+    const int opcodeCount = 20;
     const uint32_t dacTableStart1 = 2048 - 512;
     const uint32_t dacTableStart2 = dacTableStart1 - 512;
     uint32_t totalSampleWords = 2048 - 512 - 512 - (opcodeCount + 1); // add 512 for mono


### PR DESCRIPTION
Fixes for the ULP driver:
- Fix the order of mono samples (each pair was swapped)
- Remove comment on version and date (currently tracked within ESP8266Audio repo)
- Added some usage instructions to the header file
- Delete sample in buffer after being rendered (ULP) to avoid sound looping in the buffer at the end of playback
