### PR TITLE
Fix for esp8266 I2S/NoDAC

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -197,12 +197,16 @@ bool AudioOutputI2S::begin(bool txDAC)
       orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
       orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
     #ifdef I2S_HAS_BEGIN_RXTX_DRIVE_CLOCKS
-      i2s_rxtxdrive_begin(false, true, false, txDAC);
+      if (!i2s_rxtxdrive_begin(false, true, false, txDAC)) {
+        return false;
+      }
     #else
+      if (!i2s_rxtx_begin(false, true)) {
+        return false;
+      }
       if (!txDAC) {
         audioLogger->printf_P(PSTR("I2SNoDAC: esp8266 arduino core should be upgraded to avoid conflicts with SPI\n"));
       }
-      i2s_begin();
     #endif
     }
   #endif

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -129,7 +129,7 @@ bool AudioOutputI2S::SetOutputModeMono(bool mono)
   return true;
 }
 
-bool AudioOutputI2S::begin()
+bool AudioOutputI2S::begin(bool txDAC)
 {
   #ifdef ESP32
     if (!i2sOn)
@@ -196,7 +196,12 @@ bool AudioOutputI2S::begin()
     {
       orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
       orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
+    #if I2S_HAS_BEGIN_RXTXDAC
+      i2s_rxtxdac_begin(false, true, txDAC);
+    #else
+      (void)txDAC;
       i2s_begin();
+    #endif
     }
   #endif
   i2sOn = true;

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -199,7 +199,9 @@ bool AudioOutputI2S::begin(bool txDAC)
     #if I2S_HAS_BEGIN_RXTXDAC
       i2s_rxtxdac_begin(false, true, txDAC);
     #else
-      (void)txDAC;
+      if (!txDAC) {
+        audioLogger->printf_P(PSTR("I2SNoDAC: esp8266 arduino core should be upgraded to avoid conflicts with SPI\n"));
+      }
       i2s_begin();
     #endif
     }

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -196,8 +196,8 @@ bool AudioOutputI2S::begin(bool txDAC)
     {
       orig_bck = READ_PERI_REG(PERIPHS_IO_MUX_MTDO_U);
       orig_ws = READ_PERI_REG(PERIPHS_IO_MUX_GPIO2_U);
-    #if I2S_HAS_BEGIN_RXTXDAC
-      i2s_rxtxdac_begin(false, true, txDAC);
+    #ifdef I2S_HAS_BEGIN_RXTX_DRIVE_CLOCKS
+      i2s_rxtxdrive_begin(false, true, false, txDAC);
     #else
       if (!txDAC) {
         audioLogger->printf_P(PSTR("I2SNoDAC: esp8266 arduino core should be upgraded to avoid conflicts with SPI\n"));

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -32,11 +32,12 @@ class AudioOutputI2S : public AudioOutput
     virtual bool SetRate(int hz) override;
     virtual bool SetBitsPerSample(int bits) override;
     virtual bool SetChannels(int channels) override;
-    virtual bool begin() override;
+    virtual bool begin() override { return begin(true); }
     virtual bool ConsumeSample(int16_t sample[2]) override;
     virtual void flush() override;
     virtual bool stop() override;
     
+    bool begin (bool txDAC);
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
 
     enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };

--- a/src/AudioOutputI2SNoDAC.h
+++ b/src/AudioOutputI2SNoDAC.h
@@ -28,6 +28,7 @@ class AudioOutputI2SNoDAC : public AudioOutputI2S
   public:
     AudioOutputI2SNoDAC(int port = 0);
     virtual ~AudioOutputI2SNoDAC() override;
+    virtual bool begin() override { return AudioOutputI2S::begin(false); }
     virtual bool ConsumeSample(int16_t sample[2]) override;
     
     bool SetOversampling(int os);


### PR DESCRIPTION
Conflicts with repurposed GPIO, found when using SPI SS GPIO (using SDFS), are avoided.

Related: https://github.com/esp8266/Arduino/pull/7748