### PR TITLE
Modified AudioFileSource ID3 to enable tag skipping.

### DIFF
--- a/src/AudioFileSourceFS.h
+++ b/src/AudioFileSourceFS.h
@@ -29,8 +29,8 @@
 class AudioFileSourceFS : public AudioFileSource
 {
   public:
-    AudioFileSourceFS(FS &fs) { filesystem = &fs; }
-    AudioFileSourceFS(FS &fs, const char *filename);
+    AudioFileSourceFS(fs::FS &fs) { filesystem = &fs; }
+    AudioFileSourceFS(fs::FS &fs, const char *filename);
     virtual ~AudioFileSourceFS() override;
     
     virtual bool open(const char *filename) override;
@@ -42,8 +42,8 @@ class AudioFileSourceFS : public AudioFileSource
     virtual uint32_t getPos() override { if (!f) return 0; else return f.position(); };
 
   private:
-    FS *filesystem;
-    File f;
+    fs::FS *filesystem;
+    fs::File f;
 };
 
 

--- a/src/AudioFileSourceID3.cpp
+++ b/src/AudioFileSourceID3.cpp
@@ -143,6 +143,7 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
   if (ret<10) return ret;
 
   if ((buff[0]!='I') || (buff[1]!='D') || (buff[2]!='3') || (buff[3]>0x04) || (buff[3]<0x02) || (buff[4]!=0)) {
+    cb.md("eof", false, "id3");
     return 10 + src->read(buff+10, len-10);
   }
 
@@ -212,7 +213,7 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
 
       // Read the value and send to callback
       char value[64];
-      uint16_t i;
+      uint32_t i;
       bool isUnicode = (id3.getByte()==1) ? true : false;
       for (i=0; i<framesize-1; i++) {
         if (i<sizeof(value)-1) value[i] = id3.getByte();
@@ -231,9 +232,23 @@ uint32_t AudioFileSourceID3::read(void *data, uint32_t len)
       } else if ( (frameid[0]=='T' && frameid[1]=='Y' && frameid[2]=='E' && frameid[3] == 'R') ||
                   (frameid[0]=='T' && frameid[1]=='Y' && frameid[2]=='E' && rev==2) ) {
         cb.md("Year", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='R' && frameid[2]=='C' && frameid[3] == 'K') ||
+                  (frameid[0]=='T' && frameid[1]=='R' && frameid[2]=='K' && rev==2) ) {
+        cb.md("track", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='P' && frameid[2]=='O' && frameid[3] == 'S') ||
+                  (frameid[0]=='T' && frameid[1]=='P' && frameid[2]=='A' && rev==2) ) {
+        cb.md("Set", isUnicode, value);
+      } else if ( (frameid[0]=='P' && frameid[1]=='O' && frameid[2]=='P' && frameid[3] == 'M') ||
+                  (frameid[0]=='P' && frameid[1]=='O' && frameid[2]=='P' && rev==2) ) {
+        cb.md("Popularimeter", isUnicode, value);
+      } else if ( (frameid[0]=='T' && frameid[1]=='C' && frameid[2]=='M' && frameid[3] == 'P') ) {
+        cb.md("Compilation", isUnicode, value);
       }
     }
   } while (!id3.eof());
+
+  // use callback function to signal end of tags and beginning of content.
+  cb.md("eof", false, "id3");
 
   // All ID3 processing done, return to main caller
   return src->read(data, len);

--- a/src/AudioFileSourceID3.h
+++ b/src/AudioFileSourceID3.h
@@ -28,7 +28,7 @@
 class AudioFileSourceID3 : public AudioFileSource
 {
   public:
-    AudioFileSourceID3(AudioFileSource *src);
+    AudioFileSourceID3(AudioFileSource *src, bool skip = false);
     virtual ~AudioFileSourceID3() override;
     
     virtual uint32_t read(void *data, uint32_t len) override;
@@ -41,6 +41,7 @@ class AudioFileSourceID3 : public AudioFileSource
   private:
     AudioFileSource *src;
     bool checked;
+    bool skip;
 };
 
 


### PR DESCRIPTION
Hello,

This follows the issue #349 opened sooner this day, about the random buffer silence / noise at the beginning of a mp3 play.

For what I understand, when reading a mp3, two things can happen : 
- we want to read tags : an AudioFileSourceID3 object is created, which is called from AudioGeneratorMP3. It reads the tags, and simply relays the data from file when the job is done. Fine, when the tags have been read the music starts.
- we don't want to read tags : an AudioFileSourceXXX is created, but between the beginning of the file and the beginning of audio data (_i.e._ when in tag data), the AudioOutputXXX reads from a buffer which is not updated.

So, I've modified the AudioFileSourceID3 to add the following : a `bool skip` member variable, that can be changed in the constructor, and defaults to 0 : `AudioFileSourceID3(AudioFileSource *src, bool skip = false);`

This variable is tested once the tag header has been parsed, and its size is known. If true, the size of the tag section is skipped, and music can start immediately.
