### PR TITLE
Ensure only 1 ICY packet processed per reading

### DIFF
--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -83,6 +83,8 @@ AudioFileSourceICYStream::~AudioFileSourceICYStream()
 
 uint32_t AudioFileSourceICYStream::readInternal(void *data, uint32_t len, bool nonBlock)
 {
+  // Ensure we can't possibly read 2 ICY headers in a single go #355
+  len = std::min((int)(icyMetaInt >> 1), (int)len);
 retry:
   if (!http.connected()) {
     cb.st(STATUS_DISCONNECTED, PSTR("Stream disconnected"));


### PR DESCRIPTION
Thanks to @cjwhoishe, fixes #355 .

When a large enough read size was requested it is possible that for some
streams multiple ICY blocks could appear.  The logic doesn't support
that, so only read up to 1/2 the ICY block interval to ensure there is
no way to see two ICY blocks in one readInternal call.