### PR TITLE
Proposal for various tiny fixes

### DIFF
--- a/examples/StreamMP3FromHTTP/StreamMP3FromHTTP.ino
+++ b/examples/StreamMP3FromHTTP/StreamMP3FromHTTP.ino
@@ -22,7 +22,7 @@ const char* ssid = STASSID;
 const char* password = STAPSK;
 
 // Randomly picked URL
-const char *URL="http://streaming.shoutcast.com/80sPlanet?lang=en-US";
+const char *URL="http://kvbstreams.dyndns.org:8000/wkvi-am";
 
 AudioGeneratorMP3 *mp3;
 AudioFileSourceICYStream *file;

--- a/examples/StreamOnHost/AudioOutputNullSlow.h
+++ b/examples/StreamOnHost/AudioOutputNullSlow.h
@@ -1,0 +1,52 @@
+/*
+  AudioOutput
+  Base class of an audio output player
+  
+  Copyright (C) 2017  Earle F. Philhower, III
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _AUDIOOUTPUTNULLSLOW_H
+#define _AUDIOOUTPUTNULLSLOW_H
+
+#include "AudioOutput.h"
+
+class AudioOutputNullSlow : public AudioOutput 
+{
+  public:
+    AudioOutputNullSlow(int hertz) { SetRate(hertz); };
+    ~AudioOutputNullSlow() {};
+    virtual bool begin() { samples = 0; startms = millis(); return true; }
+    virtual bool ConsumeSample(int16_t sample[2]) {
+        (void)sample;
+        samples++;
+        usleep(1000000/hertz);
+        // return false (= output buffer full)
+        // sometimes to let the main loop running
+        return (samples & ((1<<12)-1)) != 0;
+    }
+    virtual bool stop() { endms = millis(); return true; };
+    unsigned long GetMilliseconds() { return endms - startms; }
+    int GetSamples() { return samples; }
+    int GetFrequency() { return hertz; }
+
+  protected:
+    unsigned long startms;
+    unsigned long endms;
+    int samples;
+};
+
+#endif
+

--- a/examples/StreamOnHost/AudioOutputNullSlow.h
+++ b/examples/StreamOnHost/AudioOutputNullSlow.h
@@ -30,12 +30,14 @@ class AudioOutputNullSlow : public AudioOutput
     ~AudioOutputNullSlow() {};
     virtual bool begin() { samples = 0; startms = millis(); return true; }
     virtual bool ConsumeSample(int16_t sample[2]) {
-        (void)sample;
-        samples++;
-        usleep(1000000/hertz);
         // return false (= output buffer full)
         // sometimes to let the main loop running
-        return (samples & ((1<<12)-1)) != 0;
+        constexpr int everylog2 = 10;
+        if ((++samples & ((1<<everylog2)-1)) == 0) {
+            delay(1000/(hertz >> everylog2));
+            return false;
+        }
+        return true;
     }
     virtual bool stop() { endms = millis(); return true; };
     unsigned long GetMilliseconds() { return endms - startms; }

--- a/examples/StreamOnHost/StreamOnHost.ino
+++ b/examples/StreamOnHost/StreamOnHost.ino
@@ -8,27 +8,27 @@
 #include "AudioFileSourceICYStream.h"
 #include "AudioFileSourceBuffer.h"
 #include "AudioGeneratorMP3.h"
-#include "AudioOutputNull.h"
+#include "AudioOutputNullSlow.h"
 
 // To run, set your ESP8266 build to 160MHz, update the SSID info, and upload.
 
 // Enter your WiFi setup here:
 #ifndef STASSID
-#define STASSID ""
-#define STAPSK  ""
+#define STASSID "your-ssid"
+#define STAPSK  "your-password"
 #endif
 
 const char* ssid = STASSID;
 const char* password = STAPSK;
 
 // Randomly picked URL
-const char *URL="http://icecast.radiofrance.fr/franceinter-lofi.mp3";
-//const char *URL="http://kvbstreams.dyndns.org:8000/wkvi-am";
+const char *URL="http://kvbstreams.dyndns.org:8000/wkvi-am";
+//const char *URL="http://icecast.radiofrance.fr/franceinter-lofi.mp3";
 
 AudioGeneratorMP3 *mp3;
 AudioFileSourceICYStream *file;
 AudioFileSourceBuffer *buff;
-AudioOutputNull *out;
+AudioOutputNullSlow *out;
 
 // Called when a metadata event occurs (i.e. an ID3 tag, an ICY block, etc.
 void MDCallback(void *cbData, const char *type, bool isUnicode, const char *string)
@@ -80,9 +80,9 @@ void setup()
   audioLogger = &Serial;
   file = new AudioFileSourceICYStream(URL);
   file->RegisterMetadataCB(MDCallback, (void*)"ICY");
-  buff = new AudioFileSourceBuffer(file, 4096);
+  buff = new AudioFileSourceBuffer(file, 2048);
   buff->RegisterStatusCB(StatusCallback, (void*)"buffer");
-  out = new AudioOutputNull();
+  out = new AudioOutputNullSlow(44100);
   mp3 = new AudioGeneratorMP3();
   mp3->RegisterStatusCB(StatusCallback, (void*)"mp3");
   mp3->begin(buff, out);

--- a/examples/StreamOnHost/onHost
+++ b/examples/StreamOnHost/onHost
@@ -17,16 +17,22 @@ if [ "$1" = "clean" ]; then
     cd ${THISLIB}
     rm -f src/*.o src/libmad/*.o
     exit 0
-fi
-
-if [ "$1" = "-h" ]; then
+elif [ "$1" = diff ]; then
+    cd ${THISLIB}/examples
+    diff -u StreamMP3FromHTTP/StreamMP3FromHTTP.ino ${ino}/${ino}.ino
+    exit 0
+else
+    echo ""
     echo "usage:"
     echo "  $0"
     echo "  $0 clean"
+    echo "  $0 diff"
     echo "  FORCE32=0 $0   (run with valgrind)"
     echo "  FORCE32=1 $0   (run in 32 bits)"
     echo "variable ESP8266ARDUINO must point to esp8266 Arduino core directory"
-    exit 0
+    echo ""
+    [ "$1" = "-h" ] && exit 0
+    sleep 1
 fi
 
 [ -z "${FORCE32}" ] && FORCE32=0
@@ -37,7 +43,7 @@ else
     run=
 fi
 
-eval make FORCE32=${FORCE32} V=1 -j \
+eval make FORCE32=${FORCE32} -j \
     USERCSOURCES=\"${MAD}\" \
     USERCXXSOURCES=\"${THISLIB}/src/AudioFileSourceBuffer.cpp ${THISLIB}/src/AudioLogger.cpp ${THISLIB}/src/AudioGeneratorMP3.cpp ${THISLIB}/src/AudioFileSourceICYStream.cpp ${THISLIB}/src/AudioFileSourceHTTPStream.cpp\" \
     USERCFLAGS=\"-I${THISLIB}/src/\" \

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -84,7 +84,7 @@ retry:
     cb.st(STATUS_DISCONNECTED, PSTR("Stream disconnected"));
     http.end();
     for (int i = 0; i < reconnectTries; i++) {
-      char buff[32];
+      char buff[64];
       sprintf_P(buff, PSTR("Attempting to reconnect, try %d"), i);
       cb.st(STATUS_RECONNECTING, buff);
       delay(reconnectDelayMs);

--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -84,13 +84,15 @@ AudioFileSourceICYStream::~AudioFileSourceICYStream()
 uint32_t AudioFileSourceICYStream::readInternal(void *data, uint32_t len, bool nonBlock)
 {
   // Ensure we can't possibly read 2 ICY headers in a single go #355
-  len = std::min((int)(icyMetaInt >> 1), (int)len);
+  if (icyMetaInt > 1) {
+    len = std::min((int)(icyMetaInt >> 1), (int)len);
+  }
 retry:
   if (!http.connected()) {
     cb.st(STATUS_DISCONNECTED, PSTR("Stream disconnected"));
     http.end();
     for (int i = 0; i < reconnectTries; i++) {
-      char buff[32];
+      char buff[64];
       sprintf_P(buff, PSTR("Attempting to reconnect, try %d"), i);
       cb.st(STATUS_RECONNECTING, buff);
       delay(reconnectDelayMs);


### PR DESCRIPTION

- In the ICY recent fix, add a check for `icyMetaInt` that has been seen to be 0
- Two short buffer size (seen by compiler when using emulation on host)
- `StreamOnHost` example:
  - Make it slower so it can reveal some issue with some URL
  - Make it look like better with the real HTTP example
  - Always show cmdline help in the `./onHost` script