### PR TITLE
Fix compile error due to insufficient capacity

### DIFF
--- a/examples/PlayWAVFromPROGMEM/PlayWAVFromPROGMEM.ino
+++ b/examples/PlayWAVFromPROGMEM/PlayWAVFromPROGMEM.ino
@@ -1,9 +1,4 @@
 #include <Arduino.h>
-#ifdef ESP32
-    #include <WiFi.h>
-#else
-    #include <ESP8266WiFi.h>
-#endif
 
 #include "AudioFileSourcePROGMEM.h"
 #include "AudioGeneratorWAV.h"
@@ -18,7 +13,6 @@ AudioOutputI2SNoDAC *out;
 
 void setup()
 {
-  WiFi.mode(WIFI_OFF); 
   Serial.begin(115200);
   delay(1000);
   Serial.printf("WAV start\n");


### PR DESCRIPTION
Remove unused WiFi library from `PlayWAVFromPROGMEM.ino` to reduce the storage capacity. Found on esp32 v1.0.6 on Arduino IDE.

> Sketch uses 1332662 bytes (101%) of program storage space. Maximum is 1310720 bytes.
> Global variables use 38648 bytes (11%) of dynamic memory, leaving 289032 bytes for local variables. Maximum is 327680 bytes.
> text section exceeds available space in board
> Sketch too big; see http://www.arduino.cc/en/Guide/Troubleshooting#size for tips on reducing it.
> Error compiling for board ESP32 Dev Module.
