### PR TITLE
Adding support for Tranfer-Encoding: chunked streams

### DIFF
--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -24,16 +24,58 @@
 
 AudioFileSourceHTTPStream::AudioFileSourceHTTPStream()
 {
+ // init_ascii_to_hex();
   pos = 0;
   reconnectTries = 0;
   saveURL[0] = 0;
+  next_chunk = 0;
 }
 
 AudioFileSourceHTTPStream::AudioFileSourceHTTPStream(const char *url)
 {
+  //init_ascii_to_hex();
   saveURL[0] = 0;
   reconnectTries = 0;
+  next_chunk = 0;
   open(url);
+
+}
+
+int AudioFileSourceHTTPStream::convertHexToInt(const char *str)
+{
+  int result = 0;
+  while(*str)
+  {
+    if(!((*str <= '9' && *str >= '0') || (*str <= 'f' && *str >= 'a')))
+    {
+      audioLogger->printf("Character not HEX");
+      return -1;
+    }
+    result = (result << 4) | ascii_to_hex[*str];
+    ++str; 
+  }
+
+  return result;
+}
+
+bool AudioFileSourceHTTPStream::verifyCrlf()
+{
+  
+  uint8_t crlf[3];
+  
+  client.read(crlf, 2);
+  crlf[2] = 0;
+  
+  String crlfString = "\r\n";
+  return crlfString == String((char*)crlf);
+}
+
+int AudioFileSourceHTTPStream::getChunkSize()
+{
+  String length = client.readStringUntil('\r');
+  String lf = client.readStringUntil('\n');
+  
+  return  convertHexToInt(length.c_str());
 }
 
 bool AudioFileSourceHTTPStream::open(const char *url)
@@ -44,12 +86,37 @@ bool AudioFileSourceHTTPStream::open(const char *url)
 #ifndef ESP32
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
 #endif
+  const char* headers[] = { "Transfer-Encoding" };
+  http.collectHeaders( headers, 1 );
   int code = http.GET();
   if (code != HTTP_CODE_OK) {
     http.end();
     cb.st(STATUS_HTTPFAIL, PSTR("Can't open HTTP request"));
     return false;
   }
+  if (http.hasHeader("Transfer-Encoding")) {
+    audioLogger->printf_P(PSTR("Transfer-Encoding: %s\n"), http.header("Transfer-Encoding").c_str());
+    if(http.header("Transfer-Encoding") == String("chunked")) {
+      
+      next_chunk = getChunkSize();
+      if(-1 == next_chunk) 
+      {
+        return false;
+      }
+      is_chunked = true;
+      readImpl = &AudioFileSourceHTTPStream::readChunked;
+    } else {
+      is_chunked = false;
+      readImpl = &AudioFileSourceHTTPStream::readRegular;
+    }
+
+  } else {
+    readImpl = &AudioFileSourceHTTPStream::readRegular;
+    audioLogger->printf_P(PSTR("No Transfer-Encoding\n"));
+    is_chunked = false;
+  }
+ 
+
   size = http.getSize();
   strncpy(saveURL, url, sizeof(saveURL));
   saveURL[sizeof(saveURL)-1] = 0;
@@ -61,13 +128,58 @@ AudioFileSourceHTTPStream::~AudioFileSourceHTTPStream()
   http.end();
 }
 
+uint32_t AudioFileSourceHTTPStream::readRegular(void *data, uint32_t len, bool nonBlock)
+{
+  return readInternal(data, len, nonBlock);
+}
+
+uint32_t AudioFileSourceHTTPStream::readChunked(void *data, uint32_t len, bool nonBlock)
+{
+  uint32_t bytesRead = 0;
+  uint32_t pos = 0;
+  
+  while(len > 0)
+  {
+    if(len >= next_chunk)
+    {
+      while (next_chunk)
+      {
+        bytesRead = readInternal(data + pos, next_chunk, nonBlock);
+        next_chunk -= bytesRead;
+        pos += bytesRead;
+      }
+      len -= pos;
+      if(!verifyCrlf())
+      {
+        audioLogger->printf("Couldn't read CRLF after chunk, something is wrong !!\n");
+        return 0;
+      }
+      next_chunk = getChunkSize();
+    }
+    else
+    {
+      bytesRead = readInternal(data + pos, len, nonBlock);
+      next_chunk -= bytesRead;
+      len -= bytesRead;
+      pos += bytesRead;
+    }
+    
+  }
+  
+  
+  return pos;
+}
+
 uint32_t AudioFileSourceHTTPStream::read(void *data, uint32_t len)
 {
   if (data==NULL) {
     audioLogger->printf_P(PSTR("ERROR! AudioFileSourceHTTPStream::read passed NULL data\n"));
     return 0;
   }
-  return readInternal(data, len, false);
+  //return readInternal(data, len, false);
+  
+  return (this->*readImpl)(data, len, false);
+
 }
 
 uint32_t AudioFileSourceHTTPStream::readNonBlock(void *data, uint32_t len)
@@ -76,7 +188,8 @@ uint32_t AudioFileSourceHTTPStream::readNonBlock(void *data, uint32_t len)
     audioLogger->printf_P(PSTR("ERROR! AudioFileSourceHTTPStream::readNonBlock passed NULL data\n"));
     return 0;
   }
-  return readInternal(data, len, true);
+  return (this->*readImpl)(data, len, true);
+
 }
 
 uint32_t AudioFileSourceHTTPStream::readInternal(void *data, uint32_t len, bool nonBlock)

--- a/src/AudioFileSourceHTTPStream.h
+++ b/src/AudioFileSourceHTTPStream.h
@@ -21,6 +21,8 @@
 #if defined(ESP32) || defined(ESP8266)
 #pragma once
 
+#include <map> // std::map<char, int> ascii_to_hex;
+
 #include <Arduino.h>
 #ifdef ESP32
   #include <HTTPClient.h>
@@ -28,6 +30,8 @@
   #include <ESP8266HTTPClient.h>
 #endif
 #include "AudioFileSource.h"
+
+
 
 class AudioFileSourceHTTPStream : public AudioFileSource
 {
@@ -52,7 +56,8 @@ class AudioFileSourceHTTPStream : public AudioFileSource
     enum { STATUS_HTTPFAIL=2, STATUS_DISCONNECTED, STATUS_RECONNECTING, STATUS_RECONNECTED, STATUS_NODATA };
 
   private:
-    virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
+    bool is_chunked;
+    std::size_t next_chunk;
     WiFiClient client;
     HTTPClient http;
     int pos;
@@ -60,6 +65,33 @@ class AudioFileSourceHTTPStream : public AudioFileSource
     int reconnectTries;
     int reconnectDelayMs;
     char saveURL[128];
+    uint32_t (AudioFileSourceHTTPStream::*readImpl)(void *data, uint32_t len, bool nonBlock);
+
+    virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
+    uint32_t readChunked(void *data, uint32_t len, bool nonBlock);
+    uint32_t readRegular(void *data, uint32_t len, bool nonBlock);
+    bool verifyCrlf();
+    int convertHexToInt(const char *str);
+    int getChunkSize();
+
+    std::map<char, unsigned char> ascii_to_hex = {
+      { '0', 0 },
+      { '1', 1 },
+      { '2', 2 },
+      { '3', 3 },
+      { '4', 4 },
+      { '5', 5 },
+      { '6', 6 },
+      { '7', 7 },
+      { '8', 8 },
+      { '9', 9 },
+      { 'a', 10 },
+      { 'b', 11 },
+      { 'c', 12 },
+      { 'd', 13 },
+      { 'e', 14 },
+      { 'f', 15 },
+    };
 };
 
 


### PR DESCRIPTION
Howdy Earl !

I first started using your great library just a while ago. I wanted to have a ESP8266 as a Radio player in my home since my radio reception in my home is not that good. So I did all the setup, but then I always got the `lost synchronization..` error. <br>
First googling, all I could find is "Try encrementing your buffer size", with no help.

After some research, I realized that the stream of my favorite radio station is using a `Transfer-Encoding: chunked`, and that what caused the loss of synchronization.

So I pulled up my sleeves and added support in the `AudioFileSourceHTTPStream` class to chunked Transfer-Encoding.

This could be also implemented in the ICY class as well, but for me it wasn't all that important and all the ICY thing was quite complex, so I didn't get to it.

Hope it will solve some other folks' same problem as well. 

 This is the radio stream I'm using if you want to check it out.

http://kanliveicy.media.kan.org.il/icy/749624_mp3