### PR TITLE
i2s on esp8266: fix include

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -21,9 +21,7 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include "driver/i2s.h"
-#elif defined(ESP8266)
-  #include <i2s.h>
-#elif defined(ARDUINO_ARCH_RP2040)
+#elif defined(ARDUINO_ARCH_RP2040) || defined(ESP8266)
   #include <I2S.h>
 #endif
 #include "AudioOutputI2S.h"

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -21,9 +21,7 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include "driver/i2s.h"
-#elif defined(ESP8266)
-  #include <i2s.h>
-#elif defined(ARDUINO_ARCH_RP2040)
+#elif defined(ARDUINO_ARCH_RP2040) || defined(ESP8266)
   #include <I2S.h>
 #endif
 #include "AudioOutputI2SNoDAC.h"


### PR DESCRIPTION
Fix I2S on esp8266 Arduino core v>=3
I believe this change is backward compatible with older versions as well.

fixes #398 