### PR TITLE
Add basic auth feature and SSL feature.

### DIFF
--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -36,10 +36,23 @@ AudioFileSourceHTTPStream::AudioFileSourceHTTPStream(const char *url)
   open(url);
 }
 
+void AudioFileSourceHTTPStream::setClient(WiFiClient *client)
+{
+  this->client = client;
+}
+
+void AudioFileSourceHTTPStream::setAuthorization(const char *user, const char *password)
+{
+  http.setAuthorization(user, password);
+}
+
 bool AudioFileSourceHTTPStream::open(const char *url)
 {
   pos = 0;
-  http.begin(client, url);
+  if (client == nullptr) {
+    client = new WiFiClient();
+  }
+  http.begin(*client, url);
   http.setReuse(true);
 #ifndef ESP32
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);

--- a/src/AudioFileSourceHTTPStream.h
+++ b/src/AudioFileSourceHTTPStream.h
@@ -48,18 +48,20 @@ class AudioFileSourceHTTPStream : public AudioFileSource
     virtual uint32_t getPos() override;
     bool SetReconnect(int tries, int delayms) { reconnectTries = tries; reconnectDelayMs = delayms; return true; }
     void useHTTP10 () { http.useHTTP10(true); }
+    void setAuthorization(const char *user, const char *password);
+    void setClient(WiFiClient *client);
 
     enum { STATUS_HTTPFAIL=2, STATUS_DISCONNECTED, STATUS_RECONNECTING, STATUS_RECONNECTED, STATUS_NODATA };
 
   private:
     virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
-    WiFiClient client;
+    WiFiClient *client = nullptr;
     HTTPClient http;
     int pos;
     int size;
     int reconnectTries;
     int reconnectDelayMs;
-    char saveURL[128];
+    char saveURL[1024];
 };
 
 

--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -43,7 +43,7 @@ bool AudioFileSourceICYStream::open(const char *url)
 {
   static const char *hdr[] = { "icy-metaint", "icy-name", "icy-genre", "icy-br" };
   pos = 0;
-  http.begin(client, url);
+  http.begin(*client, url);
   http.addHeader("Icy-MetaData", "1");
   http.collectHeaders( hdr, 4 );
   http.setReuse(true);


### PR DESCRIPTION
# Issues
- AudioFileSourceHTTPStream lacks a basic auth feature.
- Also, SSL.

# What I created
- add setAuthorization method to AudioFileSourceHTTPStream. This method will set the basic auth setting to HTTPClient.
- add setClient method to AudioFileSourceHTTPStream. This method enables users to use WiFiClientSecure to set a root CA certificate.
