### PR TITLE
Make LittleFS file source available for ESP32

### DIFF
--- a/src/AudioFileSourceLittleFS.h
+++ b/src/AudioFileSourceLittleFS.h
@@ -21,8 +21,6 @@
 #ifndef _AUDIOFILESOURCESPIFFS_H
 #define _AUDIOFILESOURCESPIFFS_H
 
-#ifndef ESP32 // No LittleFS there, yet
-
 #include <Arduino.h>
 #include <LittleFS.h>
 
@@ -36,8 +34,6 @@ class AudioFileSourceLittleFS : public AudioFileSourceFS
     AudioFileSourceLittleFS(const char *filename) : AudioFileSourceFS(LittleFS, filename) {};
     // Others are inherited from base
 };
-
-#endif
 
 #endif
 


### PR DESCRIPTION
Now ESP32 Arduino 2.0.0 has LittleFS available.
I tested that this change works: mp3 plays fine from LittleFS.