### PR TITLE
Fix: add missing SPIFFS.begin()

### DIFF
--- a/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
+++ b/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
@@ -25,6 +25,7 @@ void setup()
   WiFi.mode(WIFI_OFF); 
 
   Serial.begin(115200);
+  SPIFFS.begin();
   Serial.println("Starting up...\n");
 
   audioLogger = &Serial;


### PR DESCRIPTION
Without this fix, there is no sound and the serial monitor shows:

```
Starting up...

[E][vfs_api.cpp:22] open(): File system is not mounted
[E][vfs_api.cpp:22] open(): File system is not mounted
BEGIN...
MIDI done
MIDI done
```

After this fix there is sound and no error on the serial monitor.
The change is similar to the code in https://github.com/earlephilhower/ESP8266Audio/blob/master/examples/PlayMP3FromSPIFFS/PlayMP3FromSPIFFS.ino