### PR TITLE
Fixing I2S includes to work with ESP8266 Arduino version < 3.0.0

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -21,8 +21,10 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include "driver/i2s.h"
-#elif defined(ARDUINO_ARCH_RP2040) || defined(ESP8266)
+#elif defined(ARDUINO_ARCH_RP2040) || ARDUINO_ESP8266_MAJOR >= 3
   #include <I2S.h>
+#elif ARDUINO_ESP8266_MAJOR < 3
+  #include <i2s.h>
 #endif
 #include "AudioOutputI2S.h"
 

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -21,8 +21,10 @@
 #include <Arduino.h>
 #ifdef ESP32
   #include "driver/i2s.h"
-#elif defined(ARDUINO_ARCH_RP2040) || defined(ESP8266)
+#elif defined(ARDUINO_ARCH_RP2040) || ARDUINO_ESP8266_MAJOR >= 3
   #include <I2S.h>
+#elif ARDUINO_ESP8266_MAJOR < 3
+  #include <i2s.h>
 #endif
 #include "AudioOutputI2SNoDAC.h"
 


### PR DESCRIPTION
Recent releases of ESP8266Audio doesn't compile (on Linux) with ESP8266 Arduino versions before 3.0.0. This is due to i2s.h being changed to upper case.

This PR considers the version of Arduino to include the right header file.