### PR TITLE
ESP32-C3 Support

### DIFF
--- a/src/AudioFileSourceSPIRAMBuffer.cpp
+++ b/src/AudioFileSourceSPIRAMBuffer.cpp
@@ -105,7 +105,7 @@ uint32_t AudioFileSourceSPIRAMBuffer::read(void *data, uint32_t len)
     }
 
     // Read up to the entire buffer from RAM
-    uint32_t toReadFromBuffer = std::min(len, writePtr - readPtr);
+    uint32_t toReadFromBuffer = std::min(len, (uint32_t)(writePtr - readPtr));
     uint8_t *ptr = reinterpret_cast<uint8_t*>(data);
     if (toReadFromBuffer > 0) {
 #ifdef FAKERAM

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -166,11 +166,19 @@ bool AudioOutputI2S::begin(bool txDAC)
       i2s_mode_t mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
       if (output_mode == INTERNAL_DAC)
       {
+#ifdef I2S_MODE_DAC_BUILT_IN
         mode = (i2s_mode_t)(mode | I2S_MODE_DAC_BUILT_IN);
+#else
+        return false;      
+#endif
       }
-      else if (output_mode == INTERNAL_PDM)
+      if (output_mode == INTERNAL_PDM)
       {
+#ifdef I2S_MODE_PDM
         mode = (i2s_mode_t)(mode | I2S_MODE_PDM);
+#else
+        return false;      
+#endif
       }
 
       i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
@@ -197,8 +205,12 @@ bool AudioOutputI2S::begin(bool txDAC)
       }
       if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM)
       {
+#ifdef I2S_DAC_CHANNEL_BOTH_EN
         i2s_set_pin((i2s_port_t)portNo, NULL);
         i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
+#else
+        return false;
+#endif
       }
       else
       {

--- a/src/AudioOutputSPDIF.cpp
+++ b/src/AudioOutputSPDIF.cpp
@@ -265,7 +265,7 @@ bool AudioOutputSPDIF::ConsumeSample(int16_t sample[2])
 
 #if defined(ESP32)
   // Assume DMA buffers are multiples of 16 bytes. Either we write all bytes or none.
-  uint32_t bytes_written;
+  size_t bytes_written;
   esp_err_t ret = i2s_write((i2s_port_t)portNo, (const char*)&buf, 8 * channels, &bytes_written, 0);
   // If we didn't write all bytes, return false early and do not increment frame_num
   if ((ret != ESP_OK) || (bytes_written != (8 * channels))) return false;  

--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -18,7 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef ESP32
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
 
 #include "AudioOutputULP.h"
 #include <esp32/ulp.h>


### PR DESCRIPTION
To be able to compile the library on ESP32-C3, some little changes were necessary:
- ESP32-C3 has no ULP co-processor
- uint32_t and size_t are not identical on RISC-V
- ESP32-C3 has no builtin DAC
This fixes issue https://github.com/earlephilhower/ESP8266Audio/issues/442
 