### PR TITLE
Make as much code common between AudioFileSourceHTTPStream and AudioFileSourceICYStream as possible

### DIFF
--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -45,7 +45,9 @@ bool AudioFileSourceHTTPStream::open(const char *url)
   int code = http.GET();
   if (code != HTTP_CODE_OK) {
     http.end();
-    cb.st(STATUS_HTTPFAIL, PSTR("Can't open HTTP request"));
+    char buff[64];
+    sprintf_P(buff, PSTR("Can't open HTTP request (code %d)"), code);
+    cb.st(STATUS_HTTPFAIL, buff);
     return false;
   }
   size = http.getSize();

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -41,9 +41,7 @@ bool AudioFileSourceHTTPStream::open(const char *url)
   pos = 0;
   http.begin(client, url);
   http.setReuse(true);
-#ifndef ESP32
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
-#endif
   int code = http.GET();
   if (code != HTTP_CODE_OK) {
     http.end();

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -38,8 +38,13 @@ AudioFileSourceHTTPStream::AudioFileSourceHTTPStream(const char *url)
 
 bool AudioFileSourceHTTPStream::open(const char *url)
 {
-  pos = 0;
   http.begin(client, url);
+  return openInternal(url);
+}
+
+bool AudioFileSourceHTTPStream::openInternal(const char *url)
+{
+  pos = 0;
   http.setReuse(true);
   http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS);
   int code = http.GET();
@@ -123,6 +128,11 @@ retry:
   if (avail == 0) return 0;
   if (avail < len) len = avail;
 
+  return parseInternal(stream, data, len);
+}
+
+uint32_t AudioFileSourceHTTPStream::parseInternal(WiFiClient *stream, void *data, uint32_t len)
+{
   int read = stream->read(reinterpret_cast<uint8_t*>(data), len);
   pos += read;
   return read;

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -96,7 +96,9 @@ retry:
       }
     }
     if (!http.connected()) {
-      cb.st(STATUS_DISCONNECTED, PSTR("Unable to reconnect"));
+      if (reconnectTries != 0) {
+        cb.st(STATUS_DISCONNECTED, PSTR("Unable to reconnect"));
+      }
       return 0;
     }
   }

--- a/src/AudioFileSourceHTTPStream.h
+++ b/src/AudioFileSourceHTTPStream.h
@@ -51,8 +51,12 @@ class AudioFileSourceHTTPStream : public AudioFileSource
 
     enum { STATUS_HTTPFAIL=2, STATUS_DISCONNECTED, STATUS_RECONNECTING, STATUS_RECONNECTED, STATUS_NODATA };
 
+  protected:
+    bool openInternal(const char *url);
+
   private:
-    virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
+    uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
+    virtual uint32_t parseInternal(WiFiClient *stream, void *data, uint32_t len);
     WiFiClient client;
     HTTPClient http;
     int pos;

--- a/src/AudioFileSourceICYStream.h
+++ b/src/AudioFileSourceICYStream.h
@@ -35,12 +35,11 @@ class AudioFileSourceICYStream : public AudioFileSourceHTTPStream
   public:
     AudioFileSourceICYStream();
     AudioFileSourceICYStream(const char *url);
-    virtual ~AudioFileSourceICYStream() override;
     
     virtual bool open(const char *url) override;
 
   private:
-    virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock) override;
+    virtual uint32_t parseInternal(WiFiClient *stream, void *data, uint32_t len) override;
     int icyMetaInt;
     int icyByteCount;
 };


### PR DESCRIPTION
Most of the AudioFileSourceHTTPStream was repeated in AudioFileSourceICYStream which caused some inconsistencies, e.g. redirects were enabled in ICY unconditionally and in HTTP only on devices other than ESP32.

Now just the ICY-specific parts are implemented in AudioFileSourceICYStream. readInternal() is implemented only in
AudioFileSourceHTTPStream and it delegates actual stream reading and parsing to a new virtual method parseInternal(). This wasy AudioFileSourceHTTPStream can merely read the data into the buffer and AudioFileSourceICYStream can parse metadata at will.

Additionally some HTTP error callback report error code (easier debugging) and reconnection failure is not reported if reconnection was not enabled at all (less confusing). 