### PR TITLE
Support LSB Justified DACs on ESP32 (e.g. PT8211)

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -42,6 +42,7 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
 
   //set defaults
   mono = false;
+  lsb_justified = false;
   bps = 16;
   channels = 2;
   hertz = 44100;
@@ -148,6 +149,12 @@ bool AudioOutputI2S::SetOutputModeMono(bool mono)
   return true;
 }
 
+bool AudioOutputI2S::SetLsbJustified(bool lsbJustified)
+{
+  this->lsb_justified = lsbJustified;
+  return true;
+}
+
 bool AudioOutputI2S::begin(bool txDAC)
 {
   #ifdef ESP32
@@ -183,10 +190,18 @@ bool AudioOutputI2S::begin(bool txDAC)
 #endif
       }
 
-      i2s_comm_format_t comm_fmt = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
+      i2s_comm_format_t comm_fmt;
       if (output_mode == INTERNAL_DAC)
       {
-        comm_fmt = (i2s_comm_format_t)I2S_COMM_FORMAT_I2S_MSB;
+        comm_fmt = (i2s_comm_format_t) I2S_COMM_FORMAT_I2S_MSB;
+      }
+      else if (lsb_justified)
+      {
+        comm_fmt = (i2s_comm_format_t) (I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_LSB);
+      }
+      else
+      {
+        comm_fmt = (i2s_comm_format_t) (I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
       }
 
       i2s_config_t i2s_config_dac = {

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -44,6 +44,7 @@ class AudioOutputI2S : public AudioOutput
     
     bool begin(bool txDAC);
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
+    bool SetLsbJustified(bool lsbJustified);  // Allow supporting non-I2S chips, e.g. PT8211 
 
   protected:
     bool SetPinout();
@@ -51,6 +52,7 @@ class AudioOutputI2S : public AudioOutput
     uint8_t portNo;
     int output_mode;
     bool mono;
+    int lsb_justified;
     bool i2sOn;
     int dma_buf_count;
     int use_apll;


### PR DESCRIPTION
Some DACs don't support I2S but are perfectly capable of playing audio. This PR adds a method to set AudioOutputI2S from I2S to LSB Justified mode. Unfortunately the naming of constants in ESP32 SDK is far from perfect and it's inconsistent between ESP-IDF releases. 

ESP8266 SDK always sets I2S mode in i2s_rxtx_begin() so apparently there's no way to configure it. No idea how RP2040 handles that. If you'd like me to put the new code inside #ifdef ESP32, please let me know.