### PR TITLE
I2S Fix Builtin DAC&PDM on ESP32 & compiling warning ESP32-C3

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -175,7 +175,7 @@ bool AudioOutputI2S::begin(bool txDAC)
       i2s_mode_t mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
       if (output_mode == INTERNAL_DAC)
       {
-#if CONFIG_IDF_TARGET_ESP32 || SOC_I2S_SUPPORTS_DAC
+#if CONFIG_IDF_TARGET_ESP32
         mode = (i2s_mode_t)(mode | I2S_MODE_DAC_BUILT_IN);
 #else
         return false;      
@@ -183,7 +183,11 @@ bool AudioOutputI2S::begin(bool txDAC)
       }
       else if (output_mode == INTERNAL_PDM)
       {
+#if CONFIG_IDF_TARGET_ESP32
         mode = (i2s_mode_t)(mode | I2S_MODE_PDM);
+#else
+        return false;      
+#endif
       }
 
       i2s_comm_format_t comm_fmt;
@@ -226,7 +230,7 @@ bool AudioOutputI2S::begin(bool txDAC)
       }
       if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM)
       {
-#if CONFIG_IDF_TARGET_ESP32 || SOC_I2S_SUPPORTS_DAC
+#if CONFIG_IDF_TARGET_ESP32
         i2s_set_pin((i2s_port_t)portNo, NULL);
         i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
 #else

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -175,19 +175,15 @@ bool AudioOutputI2S::begin(bool txDAC)
       i2s_mode_t mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
       if (output_mode == INTERNAL_DAC)
       {
-#ifdef I2S_MODE_DAC_BUILT_IN
+#if CONFIG_IDF_TARGET_ESP32 || SOC_I2S_SUPPORTS_DAC
         mode = (i2s_mode_t)(mode | I2S_MODE_DAC_BUILT_IN);
 #else
         return false;      
 #endif
       }
-      if (output_mode == INTERNAL_PDM)
+      else if (output_mode == INTERNAL_PDM)
       {
-#ifdef I2S_MODE_PDM
         mode = (i2s_mode_t)(mode | I2S_MODE_PDM);
-#else
-        return false;      
-#endif
       }
 
       i2s_comm_format_t comm_fmt;
@@ -230,7 +226,7 @@ bool AudioOutputI2S::begin(bool txDAC)
       }
       if (output_mode == INTERNAL_DAC || output_mode == INTERNAL_PDM)
       {
-#ifdef I2S_DAC_CHANNEL_BOTH_EN
+#if CONFIG_IDF_TARGET_ESP32 || SOC_I2S_SUPPORTS_DAC
         i2s_set_pin((i2s_port_t)portNo, NULL);
         i2s_set_dac_mode(I2S_DAC_CHANNEL_BOTH_EN);
 #else

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -193,7 +193,11 @@ bool AudioOutputI2S::begin(bool txDAC)
       i2s_comm_format_t comm_fmt;
       if (output_mode == INTERNAL_DAC)
       {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
+        comm_fmt = (i2s_comm_format_t) I2S_COMM_FORMAT_STAND_MSB;
+#else
         comm_fmt = (i2s_comm_format_t) I2S_COMM_FORMAT_I2S_MSB;
+#endif
       }
       else if (lsb_justified)
       {
@@ -201,7 +205,11 @@ bool AudioOutputI2S::begin(bool txDAC)
       }
       else
       {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
+        comm_fmt = (i2s_comm_format_t) (I2S_COMM_FORMAT_STAND_I2S);
+#else
         comm_fmt = (i2s_comm_format_t) (I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB);
+#endif
       }
 
       i2s_config_t i2s_config_dac = {

--- a/src/AudioOutputSPDIF.cpp
+++ b/src/AudioOutputSPDIF.cpp
@@ -94,7 +94,11 @@ AudioOutputSPDIF::AudioOutputSPDIF(int dout_pin, int port, int dma_buf_count)
     .sample_rate = 88200, // 2 x sampling_rate 
     .bits_per_sample = I2S_BITS_PER_SAMPLE_32BIT, // 32bit words
     .channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT, // Right than left
-    .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 2, 0)
+	  .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_STAND_I2S),
+#else
+	  .communication_format = (i2s_comm_format_t)(I2S_COMM_FORMAT_I2S | I2S_COMM_FORMAT_I2S_MSB),
+#endif
     .intr_alloc_flags = ESP_INTR_FLAG_LEVEL1, // lowest interrupt priority
     .dma_buf_count = dma_buf_count,
     .dma_buf_len = DMA_BUF_SIZE_DEFAULT, // bigger buffers, reduces interrupts


### PR DESCRIPTION
The PR to make the library compatible with ESP32C3 was not fully correct: Builtin DAC&PDM functionality was lost on ESP32. This should fix it again.

Also some compiling warnings are removed about I2S_COMM_FORMAT_STAND_MSB being deprecated, when compiling in the ESP32 Arduino core v2 (IDF>=4.2)

https://github.com/earlephilhower/ESP8266Audio/issues/442