### PR TITLE
AAC playback on RISC-V processor (ESP32C3)

### DIFF
--- a/src/libhelix-aac/assembly.h
+++ b/src/libhelix-aac/assembly.h
@@ -558,7 +558,7 @@ static __inline int CLZ(int x)
 typedef union _U64 {
 	Word64 w64;
 	struct {
-#ifdef __XTENSA__		
+#if defined(__XTENSA__) || defined (__riscv)		
 		unsigned int lo32;
 		signed int   hi32;
 #else


### PR DESCRIPTION
The library produces white noise when playing AAC streams because of a little/big endian issue.