### PR TITLE
Fix RTTTL stop on ESP32

### DIFF
--- a/src/AudioGeneratorRTTTL.cpp
+++ b/src/AudioGeneratorRTTTL.cpp
@@ -41,7 +41,10 @@ AudioGeneratorRTTTL::~AudioGeneratorRTTTL()
 
 bool AudioGeneratorRTTTL::stop()
 {
-  if (!running) return true;
+  if (!file || !output)
+  {
+	  return false;
+  }
   running = false;
   output->stop();
   return file->close();


### PR DESCRIPTION
This fixes the issue that the PlayRTTTLToI2SDAC example doesn't stop at the end of the song. It has been reported twice:
- https://github.com/earlephilhower/ESP8266Audio/issues/327
- https://github.com/earlephilhower/ESP8266Audio/issues/471

The cause of the problem is the variable `running` which is set to false when the last note has been played. As a result
`output->stop()` is not called.

This should fix it. I think it needs a check to be sure that` output`/`file` is not NULL, but I am not sure on the return value true/false.

