### PR TITLE
fix for issue #474, and a few other bugs in MODGenerator

### DIFF
--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -820,7 +820,7 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
     sumR += out32 * min(Mixer.channelPanning[channel], 64) >> 6;
   }
   
-  // Downscale to BITDEPTH - a bit fast because the compiler can replaced division by constants with proper "right shift" + correct handling of sign bit
+  // Downscale to BITDEPTH - a bit faster because the compiler can replaced division by constants with proper "right shift" + correct handling of sign bit
   if (Mod.numberOfChannels <= 4) {
       // up to 4 channels
       sumL /= 4;

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -819,12 +819,8 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
     sumL += out32 * min(128 - Mixer.channelPanning[channel], 64) >> 6;
     sumR += out32 * min(Mixer.channelPanning[channel], 64) >> 6;
   }
-
-  // Downscale to BITDEPTH - original code
-  //sumL /= Mod.numberOfChannels;
-  //sumR /= Mod.numberOfChannels;
   
-  // Downscale to BITDEPTH - a bit fast because the compiler can replaced division by constants with proper "left shift" + correct handling of sign bit
+  // Downscale to BITDEPTH - a bit fast because the compiler can replaced division by constants with proper "right shift" + correct handling of sign bit
   if (Mod.numberOfChannels <= 4) {
       // up to 4 channels
       sumL /= 4;

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -232,6 +232,11 @@ bool AudioGeneratorMOD::LoadHeader()
     Mod.numberOfChannels = (temp[0] - '0') * 10 + temp[1] - '0';
   else
     Mod.numberOfChannels = 4;
+  
+  if (Mod.numberOfChannels > CHANNELS) {
+    audioLogger->printf("\nAudioGeneratorMOD::LoadHeader abort - too many channels (configured: %d, needed: %d)\n", CHANNELS, Mod.numberOfChannels);
+    return(false);
+  }
 
   return true;
 }
@@ -801,7 +806,7 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
 
     out = current;
 
-    // Integer linear interpolation - only work correctly in 16bit
+    // Integer linear interpolation - only works correctly in 16bit
     out += (next - current) * (Mixer.channelSampleOffset[channel] & ((1 << FIXED_DIVIDER) - 1)) >> FIXED_DIVIDER;
 
     // Upscale to BITDEPTH

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -417,7 +417,7 @@ bool AudioGeneratorMOD::ProcessRow()
 
     if (sampleNumber) {
       Player.lastSampleNumber[channel] = sampleNumber - 1;
-      if (!(effectParameter == 0xE && effectParameterX == NOTEDELAY))
+      if (!(effectNumber == 0xE && effectParameterX == NOTEDELAY))
         Player.volume[channel] = Mod.samples[Player.lastSampleNumber[channel]].volume;
     }
 

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -298,9 +298,9 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
     uint32_t s32;
     if (output_mode == INTERNAL_DAC)
     {
-      int16_t l = Amplify(ms[LEFTCHANNEL]) + 0x8000;
-      int16_t r = Amplify(ms[RIGHTCHANNEL]) + 0x8000;
-      s32 = (r << 16) | (l & 0xffff);
+      uint32_t l = ((int32_t)Amplify(ms[LEFTCHANNEL])) + 0x8000;
+      uint32_t r = ((int32_t)Amplify(ms[RIGHTCHANNEL])) + 0x8000;
+      s32 = ((r & 0xffff) << 16) | (l & 0xffff);
     }
     else
     {

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -298,8 +298,8 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
     uint32_t s32;
     if (output_mode == INTERNAL_DAC)
     {
-      uint32_t l = ((int32_t)Amplify(ms[LEFTCHANNEL])) + 0x8000;
-      uint32_t r = ((int32_t)Amplify(ms[RIGHTCHANNEL])) + 0x8000;
+      int16_t l = Amplify(ms[LEFTCHANNEL]) + 0x8000;
+      int16_t r = Amplify(ms[RIGHTCHANNEL]) + 0x8000;
       s32 = ((r & 0xffff) << 16) | (l & 0xffff);
     }
     else


### PR DESCRIPTION
This PR is my proposed fix for issue #474:
* fix a tricky small bug in AudioGeneratorMOD::ProcessRow, that causes incorrect treatment of a specific effect modifier.
* abort playback when more than the configured channels are required.


* fix int16 overflow in AudioGeneratorMOD::GetSample
* make AudioGeneratorMOD::GetSample deliver output in int16 (signed) format
* added saturation logic, to avoid random noise in case of over-amplification

* AudioOutputI2S.cpp internalDAC: made sample conversion to uint16 a bit safer

I'm currently working on another PR, to use the full 16bit range of output in AudioGeneratorMOD::GetSample, including preserving a few more "real" bits of accuracy that currently get lost during up-sampling, down-shifting and mixing steps.
This will also include some debugging code for up-sampling and mixing in AudioGeneratorMOD::GetSample

Cheers,
 Frank.