### PR TITLE
AudiogeneratorMOD: use full 16bit with slightly better accuracy

### DIFF
--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -805,7 +805,7 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
     next = FatBuffer.channels[channel][(samplePointer + 1 - FatBuffer.samplePointer[channel]) /*& (FATBUFFERSIZE - 1)*/];
 	
 	// preserve a few more bits from sample interpolation, by upscaling input values.
-	// This does (slightly) reduce quantization noise in higher frequencies, typicially above 8kHz.
+	// This does (slightly) reduce quantization noise in higher frequencies, typically above 8kHz.
 	// Actually we could could even gain more bits, I was just not sure if more bits would cause overflows in other conputations.
     int16_t current16 = (int16_t) current << 2;
     int16_t next16    = (int16_t) next << 2;	  
@@ -817,9 +817,9 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
     
     // Upscale to BITDEPTH, considering the we already gained two bits in the previous step
     if (Mod.numberOfChannels < 8) {
-      out32 = (int32_t)out << (BITDEPTH - 12); // 10-2; optimizes out the final devision by 4 (after panning+mixing)
+      out32 = (int32_t)out << (BITDEPTH - 12); // 10-2; optimizes out the final division by 4 (after panning+mixing)
     } else {
-      out32 = (int32_t)out << (BITDEPTH - 13); // 10-3; optimizes out the final devision by 8 (after panning+mixing)
+      out32 = (int32_t)out << (BITDEPTH - 13); // 10-3; optimizes out the final division by 8 (after panning+mixing)
     }
 	  
     // Channel volume

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -819,10 +819,10 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
 
     // Integer linear interpolation - only works correctly in 16bit
     out += (next16 - current16) * (Mixer.channelSampleOffset[channel] & ((1 << FIXED_DIVIDER) - 1)) >> FIXED_DIVIDER;
-    
+
     // Upscale to BITDEPTH, considering the we already gained two bits in the previous step
     out32 = (int32_t)out << (BITDEPTH - 10);
-	  
+
     // Channel volume
     out32 = out32 * Mixer.channelVolume[channel] >> 6;
 
@@ -847,7 +847,7 @@ void AudioGeneratorMOD::GetSample(int16_t sample[2])
       sumR /= 8;
     }
   }
-	
+
   // clip samples to 16bit (with saturation in case of overflow)
   if(sumL <= INT16_MIN) sumL = INT16_MIN;
     else if (sumL >= INT16_MAX) sumL = INT16_MAX;

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -69,6 +69,11 @@ bool AudioGeneratorMOD::stop()
     free(FatBuffer.channels[i]);
     FatBuffer.channels[i] = NULL;
   }
+
+  if(running && (file != NULL) && (file->isOpen() == true)) {
+	output->flush();  //flush I2S output buffer, if the player was actually running before.
+  }
+
   if (file) file->close();
   running = false;
   output->stop();

--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -68,7 +68,7 @@ bool AudioGeneratorMOD::stop()
   for (int i = 0; i < CHANNELS; i++) {
     free(FatBuffer.channels[i]);
     FatBuffer.channels[i] = NULL;
-  }   
+  }
   if (file) file->close();
   running = false;
   output->stop();

--- a/src/AudioGeneratorMOD.h
+++ b/src/AudioGeneratorMOD.h
@@ -67,19 +67,6 @@ class AudioGeneratorMOD : public AudioGenerator
     
     enum {ROWS = 64, SAMPLES = 31, CHANNELS = 8, NONOTE = 0xFFFF, NONOTE8 = 0xff };
 
-	  /* the next variables are only used when do_MIXER_DEBUG is defined in AudiogeneratorMod.cpp */
-	  unsigned long clip_L_counter = 0;
-	  unsigned long clip_R_counter = 0;
-	  bool first_sample = false;
-	  long sample_min_step1 = 0;
-	  long sample_max_step1 = 0;
-	  long sample_min_step2 = 0;
-	  long sample_max_step2 = 0;
-	  long sample_min_step3 = 0;
-	  long sample_max_step3 = 0;
-	  long sample_min_out = 0;
-	  long sample_max_out = 0;
-
     typedef struct Sample {
       uint16_t length;
       int8_t fineTune;

--- a/src/AudioGeneratorMOD.h
+++ b/src/AudioGeneratorMOD.h
@@ -64,8 +64,14 @@ class AudioGeneratorMOD : public AudioGenerator
     // Hz = 7159091 / (amigaPeriod * 2) for NTSC
     int AMIGA;
     void UpdateAmiga() { AMIGA = ((usePAL?7159091:7093789) / 2 / sampleRate << FIXED_DIVIDER); }
-    
+ 
+#ifdef ESP8266 // Not sure if C3/C2 have RAM constraints, maybe add them here?
+    // support max 4 channels
+    enum {ROWS = 64, SAMPLES = 31, CHANNELS = 4, NONOTE = 0xFFFF, NONOTE8 = 0xff };
+#else
+    // support max 8 channels
     enum {ROWS = 64, SAMPLES = 31, CHANNELS = 8, NONOTE = 0xFFFF, NONOTE8 = 0xff };
+#endif
 
     typedef struct Sample {
       uint16_t length;


### PR DESCRIPTION
Hi,
This is a follow-on to my previous PR. I did a few tweaks that improve the "real" resolution (from 10bit to 12-14bit).
I have also enabled 8-channel playback, however this means that many internal structures are now 2x the size - please check if this is OK from memory usage perspective.

I only have internalDAC so I could not check if its an audible improvement. However I verified that the wavform (WAV file output) looks similar (see attached picture). If you look closely at the frequency (spectral) plot, you may notice that there is less "blue noise" in the higher frequencies, as consequence of the more accurate interpolation of instrument samples.

![compare_waveform_and_spectrum](https://user-images.githubusercontent.com/91616163/148368881-a9a4a94c-c753-43af-95e9-b7cae21f94e6.png)