### PR TITLE
small fix - flush after normal end of playback

### DIFF
--- a/src/AudioGeneratorMOD.cpp
+++ b/src/AudioGeneratorMOD.cpp
@@ -70,7 +70,7 @@ bool AudioGeneratorMOD::stop()
     FatBuffer.channels[i] = NULL;
   }
 
-  if(running && (file != NULL) && (file->isOpen() == true)) {
+  if(running || ((file != NULL) && (file->isOpen() == true))) {
 	output->flush();  //flush I2S output buffer, if the player was actually running before.
   }
 


### PR DESCRIPTION
small oops in my previous PR - output->flush was not called after normal "end of song".