### PR TITLE
Fix PlatformIO library search mode

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,10 +14,13 @@
         "type": "git",
          "url": "https://github.com/earlephilhower/ESP8266Audio"
     },
-    "version": "1.9.5",
+    "version": "1.9.6",
     "homepage": "https://github.com/earlephilhower/ESP8266Audio",
     "frameworks": "Arduino",
     "examples": [
         "examples/*/*.ino"
-    ]
+    ],
+	"build": {
+		"libLDFMode": "deep"
+	}
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP8266Audio
-version=1.9.5
+version=1.9.6
 author=Earle F. Philhower, III
 maintainer=Earle F. Philhower, III
 sentence=Audio file and I2S sound playing routines for ESP8266, ESP32, and Raspberry Pi Pico RP2040


### PR DESCRIPTION
When creating a PlatformIO project referencing this library with the default options

```ini
[env:nodemcuv2]
platform = espressif8266
board = nodemcuv2
framework = arduino
lib_deps = earlephilhower/ESP8266Audio@^1.9.5
```

A simple sketch with

```cpp
#include <Arduino.h>
#include "AudioGeneratorAAC.h"
#include "AudioOutputI2S.h"
#include "AudioFileSourcePROGMEM.h"
void setup() {}
void loop() {}
```
fails to compile with not finding `ESP8266HTTPClient.h`. This is because this library uses `#ifdef` checks to check for the target architecture, but PlatformIO's [library dependency finder search mode](https://docs.platformio.org/en/latest/librarymanager/ldf.html#dependency-finder-mode) does not evaluate these checks, and finds none of the dependencies of this library, hence failing the build.

Interestingly enough, setting `deep+` or `chain+` does also not solve the problem, but `deep` does. 

This PR fixes compilations for all 3 target architectures, tested with 

```ini
[env]
framework = arduino

[env:nodemcuv2]
platform = espressif8266
board = nodemcuv2

[env:esp32dev]
platform = espressif32
board = esp32dev

[env:rp2040]
platform = https://github.com/maxgerhardt/platform-raspberrypi.git
board = pico
board_build.core = earlephilhower
platform_packages =
    maxgerhardt/framework-arduinopico@https://github.com/maxgerhardt/arduino-pico.git
    maxgerhardt/toolchain-pico@https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.3.1-a/x86_64-w64-mingw32.arm-none-eabi-7855b0c.210706.zip
```

Also increases the version by 1 minor.

As discussed in https://community.platformio.org/t/esp8266-audio-library-fails-to-compile/26070.