### PR TITLE
Allow compilation in recent ARDUINO ESP32 RELEASES 2.0.1 and 2.0.2…

### DIFF
--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -59,7 +59,9 @@
 #include "AudioGeneratorMIDI.h"
 
 /* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
+#if defined(ESP32)
 #include "core_version.h"
+#endif /* defined(ESP32) */
 #if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
 #else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
 

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -58,6 +58,11 @@
 
 #include "AudioGeneratorMIDI.h"
 
+/* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
+#include "core_version.h"
+#if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
+#else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+
 #pragma GCC optimize ("O3")
 
 #define TSF_NO_STDIO
@@ -636,4 +641,6 @@ void AudioGeneratorMIDI::MakeStreamFromAFS(AudioFileSource *src, tsf_stream *afs
   afs->close = &afs_close;
   afs->size = &afs_size;
 }
+
+#endif /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
 

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -58,12 +58,9 @@
 
 #include "AudioGeneratorMIDI.h"
 
-/* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
-#if defined(ESP32)
-#include "core_version.h"
-#endif /* defined(ESP32) */
-#if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
-#else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+#if __GNUC__ == 8
+// Do not build, GCC8 has a compiler bug
+#else // __GNUC__ == 8
 
 #pragma GCC optimize ("O3")
 
@@ -644,5 +641,5 @@ void AudioGeneratorMIDI::MakeStreamFromAFS(AudioFileSource *src, tsf_stream *afs
   afs->size = &afs_size;
 }
 
-#endif /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+#endif //__GNUC__ == 8
 

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -22,7 +22,9 @@
 #define _AUDIOGENERATORMIDI_H
 
 /* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
+#if defined(ESP32)
 #include "core_version.h"
+#endif /* defined(ESP32) */
 #if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
 #else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
 

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -21,12 +21,9 @@
 #ifndef _AUDIOGENERATORMIDI_H
 #define _AUDIOGENERATORMIDI_H
 
-/* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
-#if defined(ESP32)
-#include "core_version.h"
-#endif /* defined(ESP32) */
-#if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
-#else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+#if __GNUC__ == 8
+// Do not build, GCC8 has a compiler bug
+#else // __GNUC__ == 8
 
 #include "AudioGenerator.h"
 
@@ -183,7 +180,7 @@ class AudioGeneratorMIDI : public AudioGenerator
     short samplesRendered[256];
 };
 
-#endif /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+#endif //__GNUC__ == 8
 
 #endif
 

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -21,6 +21,11 @@
 #ifndef _AUDIOGENERATORMIDI_H
 #define _AUDIOGENERATORMIDI_H
 
+/* Temporary solution to the internal compiler error in ARDUINO_ESP32 */
+#include "core_version.h"
+#if defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2)
+#else /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
+
 #include "AudioGenerator.h"
 
 #define TSF_NO_STDIO
@@ -176,6 +181,7 @@ class AudioGeneratorMIDI : public AudioGenerator
     short samplesRendered[256];
 };
 
+#endif /* defined (ARDUINO_ESP32_RELEASE_2_0_1) || defined (ARDUINO_ESP32_RELEASE_2_0_2) */
 
 #endif
 


### PR DESCRIPTION
… by excluding AudioGeneratorMIDI
This is a temporary solution that drops MIDI support to make this library available in most recent ESP32-Arduino cores, which have a compiler bug that renders this code incompatible.

(Temporary) Fix for:
https://github.com/earlephilhower/ESP8266Audio/issues/498
https://github.com/earlephilhower/ESP8266Audio/issues/464
https://github.com/earlephilhower/ESP8266Audio/issues/440