### PR TITLE
Finish bufferred samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ AudioGeneratorRTTTL:  Enjoy the pleasures of monophonic, 4-octave ringtones on y
 ## AudioOutput classes
 AudioOutput:  Base class for all output drivers.  Takes a sample at a time and returns true/false if there is buffer space for it.  If it returns false, it is the calling object's (AudioGenerator's) job to keep the data that didn't fit and try again later.
 
-AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz. To use the internal DAC on ESP32, instantiate this class as `AudioOutputI2S(0,1)`, see example `PlayMODFromPROGMEMToDAC` and code in [AudioOutputI2S.cpp](src/AudioOutputI2S.cpp#L29) for details.
+AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz. To use the internal DAC on ESP32, instantiate this class as `AudioOutputI2S(0,AudioOutputI2S::INTERNAL_DAC)`, see example `PlayMODFromPROGMEMToDAC` and code in [AudioOutputI2S.cpp](src/AudioOutputI2S.cpp#L29) for details. To use the hardware Pulse Density Modulation (PDM) on ESP32, instantiate this class as `AudioOutputI2S(0,AudioOutputI2S::INTERNAL_PDM)`. For both later cases, default output pins are GPIO25 and GPIO26.
 
 AudioOutputI2SNoDAC:  Abuses the I2S interface to play music without a DAC.  Turns it into a 32x (or higher) oversampling delta-sigma DAC.  Use the schematic below to drive a speaker or headphone from the I2STx pin (i.e. Rx).  Note that with this interface, depending on the transistor used, you may need to disconnect the Rx pin from the driver to perform serial uploads.  Mono-only output, of course.
 
@@ -199,7 +199,8 @@ Use the `AudioOutputI2S*No*DAC` object instead of the `AudioOutputI2S` in your c
 ESP8266-GND ------------------+  |  +------+ K| 
                                  |  |      | E|
 ESP8266-I2SOUT (Rx) -----/\/\/\--+  |      \ R|
-                                    |       +-|
+or ESP32 DOUT pin                   |       +-|
+                                    |
 USB 5V -----------------------------+
 
 You may also want to add a 220uF cap from USB5V to GND just to help filter out any voltage droop during high volume playback.
@@ -212,11 +213,18 @@ ESP8266-RX(I2S tx) -- Resistor (~1K ohm, not critical) -- 2N3904 Base
 ESP8266-GND        -- 2N3904 Emitter
 USB-5V             -- Speaker + Terminal
 2N3904-Collector   -- Speaker - Terminal
+
+*For ESP32, default output pin is GPIO22. Note that GPIO25 ang GPIO26 are occupied by wclk/bclk and can not be used.
 ```
 
 *NOTE*:  A prior version of this schematic had a direct connection from the ESP8266 to the base of the transistor.  While this does provide the maximum amplitude, it also can draw more current from the 8266 than is safe, and can also cause the transistor to overheat.
 
 As of the latest ESP8266Audio release, with the software delta-sigma DAC the LRCLK and BCLK pins *can* be used by an application.  Simply use normal `pinMode` and `digitalWrite` or `digitalRead` as desired.
+
+### Hardware PDM on ESP32
+
+Hardware PDM outputs 128 * 48Khz pulses regardles of samplerate.
+It seems that currently hardware PDM either does not output constant One at maximum sample level, or does not output 3.3V voltage at pulse ( unfortunatelly I not have oscilloscope to test currently) - sound is not as loud as desired.  You may consider using software delta-sigma DAC instead.
 
 ### High pitched buzzing with the 1-T circuit
 The 1-T amp can _NOT_ drive any sort of amplified speaker.  If there is a power or USB input to the speaker, or it has lights or Bluetooth or a battery, it can _NOT_ be used with this circuit.

--- a/src/AudioGenerator.h
+++ b/src/AudioGenerator.h
@@ -43,6 +43,7 @@ class AudioGenerator
 
   protected:
     bool running;
+    bool finishing;
     AudioFileSource *file;
     AudioOutput *output;
     int16_t lastSample[2];

--- a/src/AudioOutput.h
+++ b/src/AudioOutput.h
@@ -44,6 +44,7 @@ class AudioOutput
       }
       return count;
     }
+    virtual bool finish() { return true; }
     virtual bool stop() { return false; }
     virtual void flush() { return; }
     virtual bool loop() { return true; }

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -272,6 +272,7 @@ bool AudioOutputI2S::begin(bool txDAC)
     }
   #endif
   i2sOn = true;
+  finalSamples = 2*128*dma_buf_count;
   SetRate(hertz); // Default
   return true;
 }
@@ -337,6 +338,21 @@ void AudioOutputI2S::flush()
     I2S.flush();
   #endif
 }
+
+bool AudioOutputI2S::finish()
+{
+  if (!i2sOn)
+    return true;
+
+  int16_t sample[2];
+  sample[0] = 0;
+  sample[1] = 0;
+
+  while ( finalSamples > 0 && ConsumeSample(sample)) finalSamples--;
+  
+  return finalSamples == 0;
+}
+
 
 bool AudioOutputI2S::stop()
 {

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -40,6 +40,7 @@ class AudioOutputI2S : public AudioOutput
     virtual bool begin() override { return begin(true); }
     virtual bool ConsumeSample(int16_t sample[2]) override;
     virtual void flush() override;
+    virtual bool finish() override;
     virtual bool stop() override;
     
     bool begin(bool txDAC);
@@ -63,4 +64,5 @@ class AudioOutputI2S : public AudioOutput
     uint8_t bclkPin;
     uint8_t wclkPin;
     uint8_t doutPin;
+    unsigned long finalSamples;
 };


### PR DESCRIPTION
AudioGenerator should let AudioOutput finish playing buffered samples.

Reproduction:
- ESP32, Create AudioOutputI2S with large number of buffers:  AudioOutputI2S(port, 1, 80)
- play mp3 or WAV file
=> large part of sound file is not played

The common loop:

  if (mp3->isRunning()) {
    if (!mp3->loop()) mp3->stop();
  } else {
    Serial.printf("MP3 done\n");
    delay(1000);
  }

stops AudioOutput as soon as last sample is pushed to output. All buferred samples are discarded.

Solution:
After pushing last sample, AudioGenerator should call AudioOutput->finish() as long as it returns false.
While finishing, AudioGenerator should return true from AudioGenerator->IsRunning() and AudioGenerator->loop().

Implemented for AudioOutputI2S ( and AudioOutputNoDAC effectivelly ) , and AudioGeneratorMP3 and AudioGeneratorWAV.
Other classes work as before ( not affected ).
