### PR TITLE
allow padding number of buffers to AudioOutputNoDAC constructor

### DIFF
--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -48,7 +48,7 @@ AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port, int sck) : AudioOutputI2S(441
 
 #else
 
-AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port) : AudioOutputI2S(port, false)
+AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port, int dma_buf_count) : AudioOutputI2S(port, AudioOutputI2S::EXTERNAL_I2S, dma_buf_count)
 {
   SetOversampling(32);
   lastSamp = 0;

--- a/src/AudioOutputI2SNoDAC.h
+++ b/src/AudioOutputI2SNoDAC.h
@@ -32,7 +32,7 @@ class AudioOutputI2SNoDAC : public AudioOutputI2S
 #if defined(ARDUINO_ARCH_RP2040)
     AudioOutputI2SNoDAC(int port = 28,int sck = 26);
 #else
-    AudioOutputI2SNoDAC(int port = 0);
+    AudioOutputI2SNoDAC(int port = 0, int dma_buf_count = 8);
 #endif
 
     virtual ~AudioOutputI2SNoDAC() override;


### PR DESCRIPTION
1) Allow passing number of DMA buffers to AudioOutputNoDac constructor
2) Pass correct type for "output_mode"

Existing code is not affected.