### PR TITLE
No pop sounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ AudioGeneratorRTTTL:  Enjoy the pleasures of monophonic, 4-octave ringtones on y
 ## AudioOutput classes
 AudioOutput:  Base class for all output drivers.  Takes a sample at a time and returns true/false if there is buffer space for it.  If it returns false, it is the calling object's (AudioGenerator's) job to keep the data that didn't fit and try again later.
 
-AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz. To use the internal DAC on ESP32, instantiate this class as `AudioOutputI2S(0,1)`, see example `PlayMODFromPROGMEMToDAC` and code in [AudioOutputI2S.cpp](src/AudioOutputI2S.cpp#L29) for details.
+AudioOutputI2S: Interface for any I2S 16-bit DAC.  Sends stereo or mono signals out at whatever frequency set.  Tested with Adafruit's I2SDAC and a Beyond9032 DAC from eBay.  Tested up to 44.1KHz. To use the internal DAC on ESP32, instantiate this class as `AudioOutputI2S(0,AudioOutputI2S::INTERNAL_DAC)`, see example `PlayMODFromPROGMEMToDAC` and code in [AudioOutputI2S.cpp](src/AudioOutputI2S.cpp#L29) for details. To use the hardware Pulse Density Modulation (PDM) on ESP32, instantiate this class as `AudioOutputI2S(0,AudioOutputI2S::INTERNAL_PDM)`. For both later cases, default output pins are GPIO25 and GPIO26.
 
 AudioOutputI2SNoDAC:  Abuses the I2S interface to play music without a DAC.  Turns it into a 32x (or higher) oversampling delta-sigma DAC.  Use the schematic below to drive a speaker or headphone from the I2STx pin (i.e. Rx).  Note that with this interface, depending on the transistor used, you may need to disconnect the Rx pin from the driver to perform serial uploads.  Mono-only output, of course.
 
@@ -199,7 +199,8 @@ Use the `AudioOutputI2S*No*DAC` object instead of the `AudioOutputI2S` in your c
 ESP8266-GND ------------------+  |  +------+ K| 
                                  |  |      | E|
 ESP8266-I2SOUT (Rx) -----/\/\/\--+  |      \ R|
-                                    |       +-|
+or ESP32 DOUT pin                   |       +-|
+                                    |
 USB 5V -----------------------------+
 
 You may also want to add a 220uF cap from USB5V to GND just to help filter out any voltage droop during high volume playback.
@@ -212,11 +213,18 @@ ESP8266-RX(I2S tx) -- Resistor (~1K ohm, not critical) -- 2N3904 Base
 ESP8266-GND        -- 2N3904 Emitter
 USB-5V             -- Speaker + Terminal
 2N3904-Collector   -- Speaker - Terminal
+
+*For ESP32, default output pin is GPIO22. Note that GPIO25 ang GPIO26 are occupied by wclk/bclk and can not be used.
 ```
 
 *NOTE*:  A prior version of this schematic had a direct connection from the ESP8266 to the base of the transistor.  While this does provide the maximum amplitude, it also can draw more current from the 8266 than is safe, and can also cause the transistor to overheat.
 
 As of the latest ESP8266Audio release, with the software delta-sigma DAC the LRCLK and BCLK pins *can* be used by an application.  Simply use normal `pinMode` and `digitalWrite` or `digitalRead` as desired.
+
+### Hardware PDM on ESP32
+
+Hardware PDM outputs 128 * 48Khz pulses regardles of samplerate.
+It seems that currently hardware PDM either does not output constant One at maximum sample level, or does not output 3.3V voltage at pulse ( unfortunatelly I not have oscilloscope to test currently) - sound is not as loud as desired.  You may consider using software delta-sigma DAC instead.
 
 ### High pitched buzzing with the 1-T circuit
 The 1-T amp can _NOT_ drive any sort of amplified speaker.  If there is a power or USB input to the speaker, or it has lights or Bluetooth or a battery, it can _NOT_ be used with this circuit.

--- a/README.md
+++ b/README.md
@@ -266,6 +266,17 @@ The current version allows for using the standard hardware CS (GPIO15) or any ot
 
 ![Example of SPIRAM Schematic](examples/StreamMP3FromHTTP_SPIRAM/Schema_Spiram.png)
 
+## Pop sounds (clicks)
+
+Audio wave is centered at the middle level voltage. To output silence, DAC has to output middle voltage (0x8000 sample for 16-bat DAC). PDM or PWM have to output pulse s with 50% fill. When sound is not played, pin outputs zero voltage. Thus playback start and stop can cause pop (click) sounds due to voltage change from zero to middle (3.3V/2 average). It might not be a problem with external DAC which continue generating middle voltage when I2S is stopped. There is a problem with internal DAC, PDM on ESP32 and software Delta-sigma. Even if we let I2S to run continuously (which is waste of resources), there would be clicks on each sampling rate adjustments. 
+To remove pop sounds, AudioGeneratorI2S and AudioGeneratorI2SNoDac can ramp voltage level from zero voltage to actial sound amplitude on playback start and opposite on stop.
+```
+AudioOutpupI2S->SetRamp(100)
+```
+Parameters is length of ramp in millisecons. Values between 50...100ms are Ok.  
+Volume will rize from zero to normal on sound start.
+After playback, there will be a ramp of specified length to bring voltage down to zero.
+
 ## Notes for using SD cards and ESP8266Audio on Wemos shields
 I've been told the Wemos SD card shield uses GPIO15 as the SD chip select.  This needs to be changed because GPIO15 == I2SBCLK, and is driven even if you're using the NoDAC option.  Once you move the CS to another pin and update your program it should work fine.
 

--- a/README.md
+++ b/README.md
@@ -272,10 +272,14 @@ Audio wave is centered at the middle level voltage. To output silence, DAC has t
 To remove pop sounds, AudioGeneratorI2S and AudioGeneratorI2SNoDac can ramp voltage level from zero voltage to actial sound amplitude on playback start and opposite on stop.
 ```
 AudioOutpupI2S->SetRamp(100)
+or
+AudioOutpupI2SNoDac->SetRamp(100)
 ```
 Parameters is length of ramp in millisecons. Values between 50...100ms are Ok.  
 Volume will rize from zero to normal on sound start.
 After playback, there will be a ramp of specified length to bring voltage down to zero.
+
+*Note: curently works with AudioGeneratorMP3 and AudioGeneratorWAV only*
 
 ## Notes for using SD cards and ESP8266Audio on Wemos shields
 I've been told the Wemos SD card shield uses GPIO15 as the SD chip select.  This needs to be changed because GPIO15 == I2SBCLK, and is driven even if you're using the NoDAC option.  Once you move the CS to another pin and update your program it should work fine.

--- a/src/AudioGenerator.h
+++ b/src/AudioGenerator.h
@@ -43,6 +43,7 @@ class AudioGenerator
 
   protected:
     bool running;
+    bool finishing;
     AudioFileSource *file;
     AudioOutput *output;
     int16_t lastSample[2];

--- a/src/AudioOutput.h
+++ b/src/AudioOutput.h
@@ -44,6 +44,7 @@ class AudioOutput
       }
       return count;
     }
+    virtual bool finish() { return true; }
     virtual bool stop() { return false; }
     virtual void flush() { return; }
     virtual bool loop() { return true; }

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -272,6 +272,7 @@ bool AudioOutputI2S::begin(bool txDAC)
     }
   #endif
   i2sOn = true;
+  finalSamples = 2*128*dma_buf_count;
   SetRate(hertz); // Default
   return true;
 }
@@ -337,6 +338,21 @@ void AudioOutputI2S::flush()
     I2S.flush();
   #endif
 }
+
+bool AudioOutputI2S::finish()
+{
+  if (!i2sOn)
+    return true;
+
+  int16_t sample[2];
+  sample[0] = 0;
+  sample[1] = 0;
+
+  while ( finalSamples > 0 && ConsumeSample(sample)) finalSamples--;
+  
+  return finalSamples == 0;
+}
+
 
 bool AudioOutputI2S::stop()
 {

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -40,6 +40,7 @@ class AudioOutputI2S : public AudioOutput
     virtual bool begin() override { return begin(true); }
     virtual bool ConsumeSample(int16_t sample[2]) override;
     virtual void flush() override;
+    virtual bool finish() override;
     virtual bool stop() override;
     
     bool begin(bool txDAC);
@@ -63,4 +64,5 @@ class AudioOutputI2S : public AudioOutput
     uint8_t bclkPin;
     uint8_t wclkPin;
     uint8_t doutPin;
+    unsigned long finalSamples;
 };

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -48,7 +48,7 @@ AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port, int sck) : AudioOutputI2S(441
 
 #else
 
-AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port) : AudioOutputI2S(port, false)
+AudioOutputI2SNoDAC::AudioOutputI2SNoDAC(int port, int dma_buf_count) : AudioOutputI2S(port, AudioOutputI2S::EXTERNAL_I2S, dma_buf_count)
 {
   SetOversampling(32);
   lastSamp = 0;

--- a/src/AudioOutputI2SNoDAC.h
+++ b/src/AudioOutputI2SNoDAC.h
@@ -32,7 +32,7 @@ class AudioOutputI2SNoDAC : public AudioOutputI2S
 #if defined(ARDUINO_ARCH_RP2040)
     AudioOutputI2SNoDAC(int port = 28,int sck = 26);
 #else
-    AudioOutputI2SNoDAC(int port = 0);
+    AudioOutputI2SNoDAC(int port = 0, int dma_buf_count = 8);
 #endif
 
     virtual ~AudioOutputI2SNoDAC() override;


### PR DESCRIPTION
Audio wave is centered at the middle level voltage. To output silence, DAC has to output middle voltage (0x8000 sample for 16-bit DAC). PDM or PWM have to output pulses with 50% fill. When sound is not played, pin outputs zero voltage. Thus playback start and stop can cause pop (click) sounds due to voltage change from zero to middle (3.3V/2 average). It might not be a problem with external DAC which continue generating middle voltage when I2S is stopped. There is a problem with internal DAC, PDM on ESP32 and software Delta-sigma. Even if we let I2S to run continuously (which is waste of resources), there would be clicks on each sampling rate adjustments. 
To remove pop sounds, AudioGeneratorI2S and AudioGeneratorI2SNoDac can ramp voltage level from zero voltage to actial sound amplitude on playback start and opposite on stop.

Attached archive contains two sounds with and without clicks.
There is no ramp by default.
Ramp should be enabled with call: AudioOutputI2SNoDAC->SetRamp(100);

[no_pop_sound.zip](https://github.com/earlephilhower/ESP8266Audio/files/8646808/no_pop_sound.zip)

(there is a digital noise from Sigma-delta 32).

Implementation:
Implementation contains and depends on my other pull request,s especially:
https://github.com/earlephilhower/ESP8266Audio/pull/520

On sound start, ramp will start with sound start. More precisely, ramp starts each time sampling rate is set,because sampling rate is changed few samples after mp3 playback start(!). Ideally we should ramp down when sound ends. As we do not know when AutdioGenerator will stop feeding AudioOutput, we have no other option to add a silence period after playback and ramp it down.

Feature is implemented for AudioGeneratorMP3 and AudioGeneratorWAV,sorry.
Other generators have to be modified to support playback of bufered samples:
https://github.com/earlephilhower/ESP8266Audio/pull/520

