### PR TITLE
Update for RP2040 core v2.0 new I2S

### DIFF
--- a/src/AudioFileSourceFunction.cpp
+++ b/src/AudioFileSourceFunction.cpp
@@ -25,14 +25,14 @@ AudioFileSourceFunction::AudioFileSourceFunction(float sec, uint16_t channels, u
   uint32_t len = uint32_t(sec * (float)bytes_per_sec);
 
   // RIFF chunk
-  strncpy(wav_header.riff.chunk_id, "RIFF", 4);
+  memcpy(wav_header.riff.chunk_id, "RIFF", 4);
   wav_header.riff.chunk_size = 4         // size of riff chunk w/o chunk_id and chunk_size
                              + 8 + 16    // size of format chunk
                              + 8 + len;  // size of data chunk
-  strncpy(wav_header.riff.format, "WAVE", 4);
+  memcpy(wav_header.riff.format, "WAVE", 4);
 
   // format chunk
-  strncpy(wav_header.format.chunk_id, "fmt ", 4);
+  memcpy(wav_header.format.chunk_id, "fmt ", 4);
   wav_header.format.chunk_size = 16;
   wav_header.format.format_tag = 0x0001;  // PCM
   wav_header.format.channels = channels;
@@ -42,7 +42,7 @@ AudioFileSourceFunction::AudioFileSourceFunction(float sec, uint16_t channels, u
   wav_header.format.bits_per_sample = bits_per_sample;
 
   // data chunk
-  strncpy(wav_header.data.chunk_id, "data", 4);
+  memcpy(wav_header.data.chunk_id, "data", 4);
   wav_header.data.chunk_size = len;
 
   funcs.reserve(channels);

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -52,6 +52,35 @@ AudioOutputI2S::AudioOutputI2S(int port, int output_mode, int dma_buf_count, int
   SetGain(1.0);
 }
 
+#elif defined(ARDUINO_ARCH_RP2040)
+AudioOutputI2S::AudioOutputI2S(long sampleRate, pin_size_t sck, pin_size_t data) {
+    i2sOn = false;
+    mono = false;
+    bps = 16;
+    channels = 2;
+    hertz = sampleRate;
+    bclkPin = sck;
+    doutPin = data;
+    SetGain(1.0);
+}
+#endif
+
+AudioOutputI2S::~AudioOutputI2S()
+{
+  #ifdef ESP32
+    if (i2sOn) {
+      audioLogger->printf("UNINSTALL I2S\n");
+      i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
+    }
+  #elif defined(ESP8266)
+    if (i2sOn)
+      i2s_end();
+  #elif defined(ARDUINO_ARCH_RP2040)
+    stop();
+  #endif
+  i2sOn = false;
+}
+
 bool AudioOutputI2S::SetPinout()
 {
   #ifdef ESP32
@@ -83,35 +112,6 @@ bool AudioOutputI2S::SetPinout(int bclk, int wclk, int dout)
 
   return true;
 }
-#elif defined(ARDUINO_ARCH_RP2040)
-AudioOutputI2S::AudioOutputI2S(long sampleRate, pin_size_t sck, pin_size_t data) {
-    i2sOn = false;
-    mono = false;
-    bps = 16;
-    channels = 2;
-    hertz = sampleRate;
-    bclkPin = sck;
-    doutPin = data;
-    SetGain(1.0);
-}
-#endif
-
-AudioOutputI2S::~AudioOutputI2S()
-{
-  #ifdef ESP32
-    if (i2sOn) {
-      audioLogger->printf("UNINSTALL I2S\n");
-      i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
-    }
-  #elif defined(ESP8266)
-    if (i2sOn)
-      i2s_end();
-  #elif defined(ARDUINO_ARCH_RP2040)
-    stop();
-  #endif
-  i2sOn = false;
-}
-
 bool AudioOutputI2S::SetRate(int hz)
 {
   // TODO - have a list of allowable rates from constructor, check them
@@ -123,7 +123,7 @@ bool AudioOutputI2S::SetRate(int hz)
   #elif defined(ESP8266)
       i2s_set_rate(AdjustI2SRate(hz));
   #elif defined(ARDUINO_ARCH_RP2040)
-      I2S.setFrequency(hz);
+      i2s.setFrequency(hz);
   #endif
   }
   return true;
@@ -266,9 +266,9 @@ bool AudioOutputI2S::begin(bool txDAC)
   #elif defined(ARDUINO_ARCH_RP2040)
     (void)txDAC;
     if (!i2sOn) {
-        I2S.setBCLK(bclkPin);
-	I2S.setDOUT(doutPin);
-        I2S.begin(hertz);
+        i2s.setBCLK(bclkPin);
+	i2s.setDATA(doutPin);
+        i2s.begin(hertz);
     }
   #endif
   i2sOn = true;
@@ -316,7 +316,8 @@ bool AudioOutputI2S::ConsumeSample(int16_t sample[2])
     uint32_t s32 = ((Amplify(ms[RIGHTCHANNEL])) << 16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
     return i2s_write_sample_nb(s32); // If we can't store it, return false.  OTW true
   #elif defined(ARDUINO_ARCH_RP2040)
-    return !!I2S.write((void*)ms, 4);
+    uint32_t s32 = ((Amplify(ms[RIGHTCHANNEL])) << 16) | (Amplify(ms[LEFTCHANNEL]) & 0xffff);
+    return !!i2s.write((int32_t)s32, false);
   #endif
 }
 
@@ -334,7 +335,7 @@ void AudioOutputI2S::flush()
       }
     }
   #elif defined(ARDUINO_ARCH_RP2040)
-    I2S.flush();
+    i2s.flush();
   #endif
 }
 
@@ -346,7 +347,7 @@ bool AudioOutputI2S::stop()
   #ifdef ESP32
     i2s_zero_dma_buffer((i2s_port_t)portNo);
   #elif defined(ARDUINO_ARCH_RP2040)
-    I2S.end();
+    i2s.end();
   #endif
   i2sOn = false;
   return true;

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -22,17 +22,22 @@
 
 #include "AudioOutput.h"
 
+#if defined(ARDUINO_ARCH_RP2040)
+#include <Arduino.h>
+#include <I2S.h>
+#endif
+
 class AudioOutputI2S : public AudioOutput
 {
   public:
 #if defined(ESP32) || defined(ESP8266)
     AudioOutputI2S(int port=0, int output_mode=EXTERNAL_I2S, int dma_buf_count = 8, int use_apll=APLL_DISABLE);
-    bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     enum : int { APLL_AUTO = -1, APLL_ENABLE = 1, APLL_DISABLE = 0 };
     enum : int { EXTERNAL_I2S = 0, INTERNAL_DAC = 1, INTERNAL_PDM = 2 };
 #elif defined(ARDUINO_ARCH_RP2040)
     AudioOutputI2S(long sampleRate = 44100, pin_size_t sck = 26, pin_size_t data = 28);
 #endif
+    bool SetPinout(int bclkPin, int wclkPin, int doutPin);
     virtual ~AudioOutputI2S() override;
     virtual bool SetRate(int hz) override;
     virtual bool SetBitsPerSample(int bits) override;
@@ -63,4 +68,8 @@ class AudioOutputI2S : public AudioOutput
     uint8_t bclkPin;
     uint8_t wclkPin;
     uint8_t doutPin;
+
+#if defined(ARDUINO_ARCH_RP2040)
+    I2S i2s;
+#endif
 };

--- a/src/AudioOutputI2SNoDAC.cpp
+++ b/src/AudioOutputI2SNoDAC.cpp
@@ -119,9 +119,6 @@ bool AudioOutputI2SNoDAC::ConsumeSample(int16_t sample[2])
 
   // Either send complete pulse stream or nothing
 #ifdef ESP32
-//"i2s_write_bytes" has been removed in the ESP32 Arduino 2.0.0,  use "i2s_write" instead.
-//  if (!i2s_write_bytes((i2s_port_t)portNo, (const char *)dsBuff, sizeof(uint32_t) * (oversample/32), 0))
-
   size_t i2s_bytes_written;
   i2s_write((i2s_port_t)portNo, (const char *)dsBuff, sizeof(uint32_t) * (oversample/32), &i2s_bytes_written, 0);
   if (!i2s_bytes_written){
@@ -134,9 +131,8 @@ bool AudioOutputI2SNoDAC::ConsumeSample(int16_t sample[2])
   for (int i = 32; i < oversample; i+=32)
     i2s_write_sample( dsBuff[i / 32]);
 #elif defined(ARDUINO_ARCH_RP2040)
-  int16_t *p = (int16_t *) dsBuff;
-  for (int i = 0; i < oversample / 16; i++) {
-    I2S.write(*(p++));
+  for (int i = 0; i < oversample / 32; i++) {
+    i2s.write((int32_t)dsBuff[i], true);
   }
 #endif
   return true;

--- a/src/AudioOutputSPIFFSWAV.cpp
+++ b/src/AudioOutputSPIFFSWAV.cpp
@@ -18,6 +18,8 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#if !defined(ARDUINO_ARCH_RP2040)
+
 #include <Arduino.h>
 #include <FS.h>
 #ifdef ESP32
@@ -110,4 +112,6 @@ bool AudioOutputSPIFFSWAV::stop()
   f.close();
   return true;
 }
- 
+
+
+#endif

--- a/src/AudioOutputSPIFFSWAV.h
+++ b/src/AudioOutputSPIFFSWAV.h
@@ -21,6 +21,8 @@
 #ifndef _AUDIOOUTPUTSPIFFSWAV_H
 #define _AUDIOOUTPUTSPIFFSWAV_H
 
+#if !defined(ARDUINO_ARCH_RP2040)
+
 #include <Arduino.h>
 #include <FS.h>
 
@@ -43,3 +45,4 @@ class AudioOutputSPIFFSWAV : public AudioOutput
 
 #endif
 
+#endif

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -93,7 +93,7 @@ function install_libraries()
 function install_ide()
 {
     local ide_path=$1
-    wget -q -O arduino.tar.xz https://www.arduino.cc/download.php?f=/arduino-nightly-linux64.tar.xz
+    wget -q -O arduino.tar.xz https://downloads.arduino.cc/arduino-nightly-linux64.tar.xz
     tar xf arduino.tar.xz
     mv arduino-nightly $ide_path
     export PATH="$ide_path:$PATH"


### PR DESCRIPTION
The I2S subsystem was rewritten in the RP2040 core V2.0, so update to
use the new object and calls.

Also clean up some code warnings and remove SPIFFS from the RP2040