### PR TITLE
fix: Invalid data is assigned to the right channel when playing a mono MP3.

### DIFF
--- a/src/AudioGeneratorMP3.cpp
+++ b/src/AudioGeneratorMP3.cpp
@@ -248,6 +248,10 @@ retry:
       running = false;
       goto done;
     }
+    if (lastChannels == 1)
+    {
+      lastSample[1] = lastSample[0];
+    }
   } while (running && output->ConsumeSample(lastSample));
 
 done:


### PR DESCRIPTION
Hello, Thanks for this great library and your work !

I have noticed that when I play a mono MP3, the right channel contains a buzzing sound.

https://user-images.githubusercontent.com/42724151/181280976-96016bac-9fe4-4213-b666-2deb13ee0616.MOV

On the other hand, the AAC decoder appears to assign the same data to both channels from mono data.
So, in this pull request, I copied the data from the left channel to the right channel when the data is mono, so that the buzzer-like sound is not output.

I just couldn't decide if it would be best to make the change at this location in the source code.
If you like this modification, I would be happy to hear from you, but if you have any suggestions on where I should fix it, please direct me.

Best regards.