### PR TITLE
ESP32: Fix compilation of I2S in Arduino ESP32 core 1.0.6

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -88,7 +88,9 @@ bool AudioOutputI2S::SetPinout()
       return false; // Not allowed
 
     i2s_pin_config_t pins = {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
         .mck_io_num = 0, // Unused
+#endif
         .bck_io_num = bclkPin,
         .ws_io_num = wclkPin,
         .data_out_num = doutPin,
@@ -229,8 +231,10 @@ bool AudioOutputI2S::begin(bool txDAC)
           .use_apll = use_apll, // Use audio PLL
           .tx_desc_auto_clear = true, // Silence on underflow
           .fixed_mclk = 0, // Unused
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
           .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT, // Unused
           .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT // Use bits per sample
+#endif
       };
       audioLogger->printf("+%d %p\n", portNo, &i2s_config_dac);
       if (i2s_driver_install((i2s_port_t)portNo, &i2s_config_dac, 0, NULL) != ESP_OK)

--- a/src/AudioOutputSPDIF.cpp
+++ b/src/AudioOutputSPDIF.cpp
@@ -105,8 +105,10 @@ AudioOutputSPDIF::AudioOutputSPDIF(int dout_pin, int port, int dma_buf_count)
     .use_apll = true, // Audio PLL is needed for low clock jitter
     .tx_desc_auto_clear = true, // Silence on underflow
     .fixed_mclk = 0, // Unused
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
     .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT, // Unused
     .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT // Use bits per sample
+#endif
   };
   if (i2s_driver_install((i2s_port_t)portNo, &i2s_config_spdif, 0, NULL) != ESP_OK) {
     audioLogger->println(F("ERROR: Unable to install I2S drivers"));
@@ -151,7 +153,9 @@ bool AudioOutputSPDIF::SetPinout(int bclk, int wclk, int dout)
 {
 #if defined(ESP32)
   i2s_pin_config_t pins = {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
     .mck_io_num = 0, // unused
+#endif
     .bck_io_num = bclk,
     .ws_io_num = wclk,
     .data_out_num = dout,


### PR DESCRIPTION
The last contribution broke compilation on IDF <4.4.0. This is a problem as the library now no longer compiles on ESP32 core 1.0.6, the most stable version.
AudioOutputI2S.cpp & AudioOutputSPDIF.cpp do'n't compile because of unknown mck_io_num, mclk_multiple, bits_per_chan, I2S_MCLK_MULTIPLE_DEFAULT and I2S_BITS_PER_CHAN_DEFAULT.

This PR fixes the compilation problem.