### PR TITLE
Fix build support gcc8 for other arch

### DIFF
--- a/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
+++ b/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
@@ -2,7 +2,7 @@
 
 // Do not build on GCC8, GCC8 has a compiler bug
 
-#if defined(ARDUINO_ARCH_RP2040) || (__GNUC__ == 8)
+#if defined(ARDUINO_ARCH_RP2040) || ((__GNUC__ == 8) && (__XTENSA__))
 void setup() {}
 void loop() {}
 #else

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -58,7 +58,7 @@
 
 #include "AudioGeneratorMIDI.h"
 
-#if __GNUC__ == 8
+#if (__GNUC__ == 8) && (__XTENSA__)
 // Do not build, GCC8 has a compiler bug
 #else // __GNUC__ == 8
 

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -21,7 +21,7 @@
 #ifndef _AUDIOGENERATORMIDI_H
 #define _AUDIOGENERATORMIDI_H
 
-#if __GNUC__ == 8
+#if (__GNUC__ == 8) && (__XTENSA__)
 // Do not build, GCC8 has a compiler bug
 #else // __GNUC__ == 8
 


### PR DESCRIPTION
See: https://github.com/earlephilhower/ESP8266Audio/pull/502

Tested on `toolchain-riscv32-esp @ 8.4.0+2021r2-patch3`