### PR TITLE
AudioOutputI2S  : error "I2S: register I2S object to platform failed" : destructor & stop

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -67,18 +67,7 @@ AudioOutputI2S::AudioOutputI2S(long sampleRate, pin_size_t sck, pin_size_t data)
 
 AudioOutputI2S::~AudioOutputI2S()
 {
-  #ifdef ESP32
-    if (i2sOn) {
-      audioLogger->printf("UNINSTALL I2S\n");
-      i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
-    }
-  #elif defined(ESP8266)
-    if (i2sOn)
-      i2s_end();
-  #elif defined(ARDUINO_ARCH_RP2040)
-    stop();
-  #endif
-  i2sOn = false;
+  stop();
 }
 
 bool AudioOutputI2S::SetPinout()
@@ -359,6 +348,10 @@ bool AudioOutputI2S::stop()
 
   #ifdef ESP32
     i2s_zero_dma_buffer((i2s_port_t)portNo);
+    audioLogger->printf("UNINSTALL I2S\n");
+    i2s_driver_uninstall((i2s_port_t)portNo); //stop & destroy i2s driver
+  #elif defined(ESP8266)
+    i2s_end();
   #elif defined(ARDUINO_ARCH_RP2040)
     i2s.end();
   #endif


### PR DESCRIPTION
* ESP32: When calling the destructor of AudioOutputI2S after having called the stop function, followed by creating of a new AudioOutputI2S object,  an error is shown "I2S: register I2S object to platform failed" in IDF 4.4.
This is because i2s_driver_uninstall had not been called in the destructor because i2sOn was already set to false in the function stop. 

It is necessary to call i2s_driver_uninstall before i2s_driver_install is being called again in the begin function. That is why I moved it to the stop function

* ESP8266 : the same problem with i2s_end not being called called when calling the stop function followed by the destructor bacause i2sOn is set to false in the stop function.
This results in new call to i2s_rxtx_begin without first having called i2s_end.

My idea is that also the noise on DAC is less after calling the function stop - but I am not sure about this