### PR TITLE
ESP32 AudioOutputULP fixes

### DIFF
--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -169,7 +169,7 @@ bool AudioOutputULP::begin()
       {
         RTC_SLOW_MEM[dacTableStart1 + i * 2] = create_I_WR_REG(RTC_IO_PAD_DAC1_REG,19,26,i); //dac1: 0x1D4C0121 | (i << 10)
         RTC_SLOW_MEM[dacTableStart1 + 1 + i * 2] = create_I_BXI(retAddress1); // 0x80000000 + retAddress1 * 4
-        RTC_SLOW_MEM[dacTableStart2 + i * 2] = create_I_WR_REG(RTC_IO_PAD_DAC1_REG,19,26,i); //dac2: 0x1D4C0122 | (i << 10)
+        RTC_SLOW_MEM[dacTableStart2 + i * 2] = create_I_WR_REG(RTC_IO_PAD_DAC2_REG,19,26,i); //dac2: 0x1D4C0122 | (i << 10)
         RTC_SLOW_MEM[dacTableStart2 + 1 + i * 2] = create_I_BXI(retAddress2); // 0x80000000 + retAddress2 * 4
       }
       break;

--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -18,9 +18,12 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#ifdef ESP32
 
 #include "AudioOutputULP.h"
+
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+
 #include <esp32/ulp.h>
 #include <driver/rtc_io.h>
 #include <driver/dac.h>
@@ -259,4 +262,5 @@ bool AudioOutputULP::stop()
   return true;
 }
 
+#endif
 #endif


### PR DESCRIPTION
* ULP didn't work anymore on ESP32 because of a stupid mistake: 
CONFIG_IDF_TARGET_ESP32 is only defined after #include"AudioOutputULP.h" ! So the ESP32 code was actually skipped

* Also  a small fix for stereo ULP support: stereo was in reality also mono
