### PR TITLE
AudioOutputPWM: fixed constructor for custom out-pin, added amplification

### DIFF
--- a/src/AudioOutputPWM.cpp
+++ b/src/AudioOutputPWM.cpp
@@ -22,7 +22,7 @@
 #include <Arduino.h>
 #include "AudioOutputPWM.h"
 
-AudioOutputPWM::AudioOutputPWM(long sampleRate, pin_size_t data) : pwm(data, false) {
+AudioOutputPWM::AudioOutputPWM(long sampleRate, pin_size_t data) {
     pwmOn = false;
     mono = false;
     bps = 16;

--- a/src/AudioOutputPWM.cpp
+++ b/src/AudioOutputPWM.cpp
@@ -22,7 +22,7 @@
 #include <Arduino.h>
 #include "AudioOutputPWM.h"
 
-AudioOutputPWM::AudioOutputPWM(long sampleRate, pin_size_t data) {
+AudioOutputPWM::AudioOutputPWM(long sampleRate, pin_size_t data) : pwm(data, false) {
     pwmOn = false;
     mono = false;
     bps = 16;
@@ -89,7 +89,10 @@ bool AudioOutputPWM::ConsumeSample(int16_t sample[2]) {
     ms[LEFTCHANNEL] = ms[RIGHTCHANNEL] = (ttl>>1) & 0xffff;
   }
 
-  if (pwm.available()) {
+    ms[LEFTCHANNEL] = Amplify(ms[LEFTCHANNEL]);
+    ms[RIGHTCHANNEL] = Amplify(ms[RIGHTCHANNEL]);
+
+    if (pwm.available()) {
       pwm.write((int16_t) ms[0]);
       pwm.write((int16_t) ms[1]);
       return true;

--- a/src/AudioOutputPWM.cpp
+++ b/src/AudioOutputPWM.cpp
@@ -89,10 +89,10 @@ bool AudioOutputPWM::ConsumeSample(int16_t sample[2]) {
     ms[LEFTCHANNEL] = ms[RIGHTCHANNEL] = (ttl>>1) & 0xffff;
   }
 
-    ms[LEFTCHANNEL] = Amplify(ms[LEFTCHANNEL]);
-    ms[RIGHTCHANNEL] = Amplify(ms[RIGHTCHANNEL]);
+  ms[LEFTCHANNEL] = Amplify(ms[LEFTCHANNEL]);
+  ms[RIGHTCHANNEL] = Amplify(ms[RIGHTCHANNEL]);
 
-    if (pwm.available()) {
+  if (pwm.available()) {
       pwm.write((int16_t) ms[0]);
       pwm.write((int16_t) ms[1]);
       return true;


### PR DESCRIPTION
Hej Earle,  
This PR adds PWMAudio to initializer list, which allows changing output pin per constructor.
Furthermore I added amplification.
There is a defaults-mismatch/-ambiguity regarding mono/stereo. I might take a look into it but that most likely requires some discussion.. 

