### PR TITLE
ESP32S3 support - fix compilation error ULP

### DIFF
--- a/src/AudioOutputULP.cpp
+++ b/src/AudioOutputULP.cpp
@@ -18,7 +18,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
 
 #include "AudioOutputULP.h"
 #include <esp32/ulp.h>


### PR DESCRIPTION
When compiling the library on ESP32-S3, following compilation error is shown:
ESP8266Audio\src\AudioOutputULP.cpp:29:10: fatal error: driver/dac.h: No such file or directory

As the ESP32S3 doesn't have DAC, the DAC API has been removed.