### PR TITLE
Add ability to SwapClocks(bool) on I2S. RP2040 only. Partially fixes #638

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -64,6 +64,7 @@ AudioOutputI2S::AudioOutputI2S(long sampleRate, pin_size_t sck, pin_size_t data)
     doutPin = data;
     mclkPin = 0;
     use_mclk = false;
+    swap_clocks = false;
     SetGain(1.0);
 }
 #endif
@@ -165,6 +166,15 @@ bool AudioOutputI2S::SetOutputModeMono(bool mono)
 bool AudioOutputI2S::SetLsbJustified(bool lsbJustified)
 {
   this->lsb_justified = lsbJustified;
+  return true;
+}
+
+bool AudioOutputI2S::SwapClocks(bool swap_clocks)
+{
+  if (i2sOn) {
+    return false; // Not allowed
+  }
+  this->swap_clocks = swap_clocks;
   return true;
 }
 
@@ -302,6 +312,9 @@ bool AudioOutputI2S::begin(bool txDAC)
     if (!i2sOn) {
         i2s.setBCLK(bclkPin);
 	i2s.setDATA(doutPin);
+	if (swap_clocks) {
+	  i2s.swapClocks();
+	}
         i2s.begin(hertz);
     }
   #endif

--- a/src/AudioOutputI2S.h
+++ b/src/AudioOutputI2S.h
@@ -52,6 +52,7 @@ class AudioOutputI2S : public AudioOutput
     bool SetOutputModeMono(bool mono);  // Force mono output no matter the input
     bool SetLsbJustified(bool lsbJustified);  // Allow supporting non-I2S chips, e.g. PT8211 
     bool SetMclk(bool enabled);  // Enable MCLK output (if supported)
+    bool SwapClocks(bool swap_clocks);  // Swap BCLK and WCLK
 
   protected:
     bool SetPinout();
@@ -64,6 +65,7 @@ class AudioOutputI2S : public AudioOutput
     int dma_buf_count;
     int use_apll;
     bool use_mclk;
+    bool swap_clocks;
     // We can restore the old values and free up these pins when in NoDAC mode
     uint32_t orig_bck;
     uint32_t orig_ws;


### PR DESCRIPTION
This PR partially fixes [Issue 638](https://github.com/earlephilhower/ESP8266Audio/issues/638)
It only implements the logic for rp2040, as I do not have the other boards, but it should be similar to do.