### PR TITLE
Don't SetRate() if hz already matches, fixes noisy click

### DIFF
--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -129,6 +129,11 @@ bool AudioOutputI2S::SetPinout(int bclk, int wclk, int dout, int mclk)
 bool AudioOutputI2S::SetRate(int hz)
 {
   // TODO - have a list of allowable rates from constructor, check them
+
+  if(this->hertz == hz){ // hz already set to this
+    return true;
+  }
+
   this->hertz = hz;
   if (i2sOn)
   {


### PR DESCRIPTION
Addresses #655 and likely others.

I tracked down a nasty click sound when using mixer to mix 2 stubs with MP3s , one is an long ongoing background track and the other is various sound clips played at various times.

The issue is that there is a audible click each time the second stub with the sound clip is used.

The issue seems to be related ultimately with calling i2s_set_sample_rates((i2s_port_t)portNo, AdjustI2SRate(hz)); for the second stub while the first stub is still running.

This PR adds a quick check to see if rate actually needs updating or if it matches what is currently set, eliminating the above issue as long as rates match.

