### PR TITLE
Add FlipChannels and IsolateChannel to mixer stub

### DIFF
--- a/src/AudioOutputMixer.cpp
+++ b/src/AudioOutputMixer.cpp
@@ -1,7 +1,7 @@
 /*
   AudioOutputMixer
   Simple mixer which can combine multiple inputs to a single output stream
-  
+
   Copyright (C) 2018  Earle F. Philhower, III
 
   This program is free software: you can redistribute it and/or modify
@@ -48,6 +48,27 @@ bool AudioOutputMixerStub::SetChannels(int channels)
   return parent->SetChannels(channels, id);
 }
 
+bool AudioOutputMixerStub::FlipChannels()
+{
+  this->channelsFlipped = !this->channelsFlipped;
+  return true;
+}
+
+bool AudioOutputMixerStub::FlipChannels(bool flipped)
+{
+  this->channelsFlipped = flipped;
+  return true;
+}
+
+bool AudioOutputMixerStub::IsolateChannel(uint8_t channel)
+{
+  if(channel < 0 || channel > 2){
+    return false;
+  }
+  this->channelIsolated = channel;
+  return true;
+}
+
 bool AudioOutputMixerStub::begin()
 {
   return parent->begin(id);
@@ -56,8 +77,10 @@ bool AudioOutputMixerStub::begin()
 bool AudioOutputMixerStub::ConsumeSample(int16_t sample[2])
 {
   int16_t amp[2];
-  amp[LEFTCHANNEL] = Amplify(sample[LEFTCHANNEL]);
-  amp[RIGHTCHANNEL] = Amplify(sample[RIGHTCHANNEL]);
+
+  amp[this->channelsFlipped ? RIGHTCHANNEL:LEFTCHANNEL] = (this->channelIsolated == 2) ? 0 : Amplify(sample[this->channelsFlipped ? RIGHTCHANNEL : LEFTCHANNEL]);
+  amp[this->channelsFlipped ? LEFTCHANNEL:RIGHTCHANNEL] = (this->channelIsolated == 1) ? 0 : Amplify(sample[this->channelsFlipped ? LEFTCHANNEL : RIGHTCHANNEL]);
+
   return parent->ConsumeSample(amp, id);
 }
 
@@ -156,7 +179,7 @@ bool AudioOutputMixer::begin(int id)
     return true;
   }
 }
-  
+
 AudioOutputMixerStub *AudioOutputMixer::NewInput()
 {
   for (int i=0; i<maxStubs; i++) {

--- a/src/AudioOutputMixer.h
+++ b/src/AudioOutputMixer.h
@@ -1,7 +1,7 @@
 /*
   AudioOutputMixer
   Simple mixer which can combine multiple inputs to a single output stream
-  
+
   Copyright (C) 2017  Earle F. Philhower, III
 
   This program is free software: you can redistribute it and/or modify
@@ -35,6 +35,9 @@ class AudioOutputMixerStub : public AudioOutput
     virtual bool SetRate(int hz) override;
     virtual bool SetBitsPerSample(int bits) override;
     virtual bool SetChannels(int channels) override;
+    virtual bool FlipChannels(); // Invert current state of channelsFlipped
+    virtual bool FlipChannels(bool flip); // Set channelsFlipped true/false
+    virtual bool IsolateChannel(uint8_t channel); // Isolate channel 0 both, 1 left, 2 right
     virtual bool begin() override;
     virtual bool ConsumeSample(int16_t sample[2]) override;
     virtual bool stop() override;
@@ -42,6 +45,8 @@ class AudioOutputMixerStub : public AudioOutput
   protected:
     AudioOutputMixer *parent;
     int id;
+    bool channelsFlipped = false;
+    uint8_t channelIsolated = 0;
 };
 
 // Single mixer object per output


### PR DESCRIPTION
Adds additional utilities to mixer stubs.

FlipChannels
```
stub->FlipChannels(true); // Enables Left and Right channel switch/flip for this mixer stub

stub->FlipChannels(false); // Disables Left and Right channel switch/flip for this mixer stub

stub->FlipChannels(); // Inverts current switch/flip setting

```

IsolateChanel
```
stub->IsolateChannel(1); // Isolates left channel, effectively muting right channel

stub->IsolateChannel(2); // Isolates right channel, effectively muting left channel

stub->IsolateChannel(0); // Disables channel isolation,

```

Among other things, this is useful for playing a specific channel from 2 different audio sources to a specific channel in the audio output. 

```out = new AudioOutputI2S(0,0);                    

mixer = new AudioOutputMixer(1024, out);

stub[0] = mixer->NewInput();
stub[0]->SetGain(.5);
stub[0]->IsolateChannel(1);

stub[1] = mixer->NewInput();
stub[1]->SetGain(.5);
stub[1]->IsolateChannel(2);

//stub[0]->FlipChannels(true);
//stub[1]->FlipChannels(true);
  
play_file1 = new AudioFileSourceSD("/1.mp3");
play_file2 = new AudioFileSourceSD("/2.mp3");

mp31 = new AudioGeneratorMP3();
mp32 = new AudioGeneratorMP3();

mp31->begin(play_file1, stub[0]);
mp32->begin(play_file2, stub[1]);
```

In this example, the output heard is the left channel from 1.mp3 and the right channel from 2.mp3.
