### PR TITLE
AudioGeneratorMP3::begin - Stop output on OOM

### DIFF
--- a/src/AudioGeneratorMP3.cpp
+++ b/src/AudioGeneratorMP3.cpp
@@ -1,7 +1,7 @@
 /*
   AudioGeneratorMP3
   Wrap libmad MP3 library to play audio
-  
+
   Copyright (C) 2017  Earle F. Philhower, III
 
   This program is free software: you can redistribute it and/or modify
@@ -62,7 +62,7 @@ AudioGeneratorMP3::~AudioGeneratorMP3()
     free(synth);
     free(frame);
     free(stream);
-  } 
+  }
 }
 
 
@@ -182,7 +182,7 @@ bool AudioGeneratorMP3::GetOneSample(int16_t sample[2])
     output->SetChannels(synth->pcm.channels);
     lastChannels = synth->pcm.channels;
   }
-    
+
   // If we're here, we have one decoded frame and sent 0 or more samples out
   if (samplePtr < synth->pcm.length) {
     sample[AudioOutput::LEFTCHANNEL ] = synth->pcm.samples[0][samplePtr];
@@ -190,7 +190,7 @@ bool AudioGeneratorMP3::GetOneSample(int16_t sample[2])
     samplePtr++;
   } else {
     samplePtr = 0;
-    
+
     switch ( mad_synth_frame_onens(synth, frame, nsCount++) ) {
         case MAD_FLOW_STOP:
         case MAD_FLOW_BREAK: audioLogger->printf_P(PSTR("msf1ns failed\n"));
@@ -302,6 +302,7 @@ bool AudioGeneratorMP3::begin(AudioFileSource *source, AudioOutput *output)
       synth = reinterpret_cast<struct mad_synth *>(preallocateSynthSpace);
     }
     else {
+      output->stop();
       audioLogger->printf_P("OOM error in MP3:  Want %d/%d/%d/%d bytes, have %d/%d/%d/%d bytes preallocated.\n",
           preAllocBuffSize(), preAllocStreamSize(), preAllocFrameSize(), preAllocSynthSize(),
           preallocateSize, preallocateStreamSize, preallocateFrameSize, preallocateSynthSize);
@@ -319,6 +320,7 @@ bool AudioGeneratorMP3::begin(AudioFileSource *source, AudioOutput *output)
     p += preAllocSynthSize();
     int neededBytes = p - reinterpret_cast<uint8_t *>(preallocateSpace);
     if (neededBytes > preallocateSize) {
+      output->stop();
       audioLogger->printf_P("OOM error in MP3:  Want %d bytes, have %d bytes preallocated.\n", neededBytes, preallocateSize);
       return false;
     }
@@ -336,17 +338,20 @@ bool AudioGeneratorMP3::begin(AudioFileSource *source, AudioOutput *output)
       stream = NULL;
       frame = NULL;
       synth = NULL;
+
+      output->stop();
+      audioLogger->printf_P("OOM error in MP3\n");
       return false;
     }
   }
- 
+
   mad_stream_init(stream);
   mad_frame_init(frame);
   mad_synth_init(synth);
   synth->pcm.length = 0;
   mad_stream_options(stream, 0); // TODO - add options support
   madInitted = true;
- 
+
   running = true;
   return true;
 }
@@ -413,4 +418,3 @@ extern "C" {
   }
 #endif
 }
-


### PR DESCRIPTION
AudioGeneratorMP3 starts its output, but if OOM during begin(), never stops its output.
This leads to downstream issues, including mixer not processing audio from the dead stub or any active ones.

