### PR TITLE
RTTTL: parse dot after octave

### DIFF
--- a/src/AudioGeneratorRTTTL.cpp
+++ b/src/AudioGeneratorRTTTL.cpp
@@ -236,12 +236,12 @@ bool AudioGeneratorRTTTL::GetNextNote()
     ptr++;
     note++;
   }
+  if (!ReadInt(&scale)) {
+    scale = defaultOctave;
+  }
   if ((ptr < len) && (buff[ptr] == '.')) {
     ptr++;
     dur += dur / 2;
-  }
-  if (!ReadInt(&scale)) {
-    scale = defaultOctave;
   }
   // Eat any trailing whitespace and comma
   SkipWhitespace();


### PR DESCRIPTION
According to RTTTL spec:
https://www.mobilefish.com/tutorials/rtttl/rtttl_quickguide_specification.html
> A dotted character (.) can be specified AFTER the duration-pitch-octave pair.

Before this change the note like `a4.` cannot be parsed and the tone ends.