### PR TITLE
Update for ESP32 Arduino 3.x

### DIFF
--- a/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
+++ b/examples/PlayMIDIFromSPIFFS/PlayMIDIFromSPIFFS.ino
@@ -1,8 +1,8 @@
 #include <Arduino.h>
 
-// Do not build on GCC8, GCC8 has a compiler bug
+// Do not build on Espressif GCC8+, compiler bug
 
-#if defined(ARDUINO_ARCH_RP2040) || ((__GNUC__ == 8) && (__XTENSA__))
+#if defined(ARDUINO_ARCH_RP2040) || (defined(ESP32) && (__GNUC__ >= 8) && (__XTENSA__))
 void setup() {}
 void loop() {}
 #else

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -102,7 +102,11 @@ retry:
   }
   if ((size > 0) && (pos >= size)) return 0;
 
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+  NetworkClient *stream = http.getStreamPtr();
+#else
   WiFiClient *stream = http.getStreamPtr();
+#endif
 
   // Can't read past EOF...
   if ( (size > 0) && (len > (uint32_t)(pos - size)) ) len = pos - size;

--- a/src/AudioFileSourceHTTPStream.h
+++ b/src/AudioFileSourceHTTPStream.h
@@ -53,7 +53,11 @@ class AudioFileSourceHTTPStream : public AudioFileSource
 
   private:
     virtual uint32_t readInternal(void *data, uint32_t len, bool nonBlock);
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+    NetworkClient client;
+#else
     WiFiClient client;
+#endif
     HTTPClient http;
     int pos;
     int size;

--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -115,7 +115,11 @@ retry:
   }
   if ((size > 0) && (pos >= size)) return 0;
 
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+  NetworkClient *stream = http.getStreamPtr();
+#else
   WiFiClient *stream = http.getStreamPtr();
+#endif
 
   // Can't read past EOF...
   if ( (size > 0) && (len > (uint32_t)(pos - size)) ) len = pos - size;

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -58,8 +58,8 @@
 
 #include "AudioGeneratorMIDI.h"
 
-#if (__GNUC__ == 8) && (__XTENSA__)
-// Do not build, GCC8 has a compiler bug
+#if (__GNUC__ >= 8) && (__XTENSA__)
+// Do not build, GCC8+ has a compiler bug
 #else // __GNUC__ == 8
 
 #pragma GCC optimize ("O3")

--- a/src/AudioGeneratorMIDI.cpp
+++ b/src/AudioGeneratorMIDI.cpp
@@ -58,8 +58,8 @@
 
 #include "AudioGeneratorMIDI.h"
 
-#if (__GNUC__ >= 8) && (__XTENSA__)
-// Do not build, GCC8+ has a compiler bug
+#if defined(ESP32) && (__GNUC__ >= 8) && (__XTENSA__)
+// Do not build, Espressif's GCC8+ has a compiler bug
 #else // __GNUC__ == 8
 
 #pragma GCC optimize ("O3")

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -21,8 +21,8 @@
 #ifndef _AUDIOGENERATORMIDI_H
 #define _AUDIOGENERATORMIDI_H
 
-#if (__GNUC__ >= 8) && (__XTENSA__)
-// Do not build, GCC8+ has a compiler bug
+#if defined(ESP32) && (__GNUC__ >= 8) && (__XTENSA__)
+// Do not build, Espressif's GCC8+ has a compiler bug
 #else // __GNUC__ == 8
 
 #include "AudioGenerator.h"

--- a/src/AudioGeneratorMIDI.h
+++ b/src/AudioGeneratorMIDI.h
@@ -21,8 +21,8 @@
 #ifndef _AUDIOGENERATORMIDI_H
 #define _AUDIOGENERATORMIDI_H
 
-#if (__GNUC__ == 8) && (__XTENSA__)
-// Do not build, GCC8 has a compiler bug
+#if (__GNUC__ >= 8) && (__XTENSA__)
+// Do not build, GCC8+ has a compiler bug
 #else // __GNUC__ == 8
 
 #include "AudioGenerator.h"

--- a/src/AudioOutputI2S.cpp
+++ b/src/AudioOutputI2S.cpp
@@ -198,9 +198,9 @@ bool AudioOutputI2S::begin(bool txDAC)
       {
         // don't use audio pll on buggy rev0 chips
         use_apll = APLL_DISABLE;
-        esp_chip_info_t out_info;
-        esp_chip_info(&out_info);
-        if (out_info.revision > 0)
+        //esp_chip_info_t out_info;
+        //esp_chip_info(&out_info);
+        //if (out_info.revision > 0)
         {
           use_apll = APLL_ENABLE;
         }

--- a/src/AudioOutputSPDIF.cpp
+++ b/src/AudioOutputSPDIF.cpp
@@ -105,7 +105,10 @@ AudioOutputSPDIF::AudioOutputSPDIF(int dout_pin, int port, int dma_buf_count)
     .use_apll = true, // Audio PLL is needed for low clock jitter
     .tx_desc_auto_clear = true, // Silence on underflow
     .fixed_mclk = 0, // Unused
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && ESP_ARDUINO_VERSION_MAJOR >= 3
+    .mclk_multiple = I2S_MCLK_MULTIPLE_512, // Unused
+    .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT // Use bits per sample
+#elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
     .mclk_multiple = I2S_MCLK_MULTIPLE_DEFAULT, // Unused
     .bits_per_chan = I2S_BITS_PER_CHAN_DEFAULT // Use bits per sample
 #endif
@@ -183,12 +186,14 @@ bool AudioOutputSPDIF::SetRate(int hz)
   int adjustedHz = AdjustI2SRate(hz);
 #if defined(ESP32)
   if (i2s_set_sample_rates((i2s_port_t)portNo, adjustedHz) == ESP_OK) {
+#if defined(ESP_ARDUINO_VERSION_MAJOR) && (ESP_ARDUINO_VERSION_MAJOR < 3)
     if (adjustedHz == 88200) {
       // Manually fix the APLL rate for 44100. 
       // See: https://github.com/espressif/esp-idf/issues/2634
       // sdm0 = 28, sdm1 = 8, sdm2 = 5, odir = 0 -> 88199.977
       rtc_clk_apll_enable(1, 28, 8, 5, 0); 
     }
+#endif
   } else {
     audioLogger->println("ERROR changing S/PDIF sample rate");
   } 

--- a/src/libhelix-mp3/mpadecobjfixpt.h
+++ b/src/libhelix-mp3/mpadecobjfixpt.h
@@ -70,7 +70,7 @@ public:
     //                          return.
     //              pPCM        pointer to a buffer to decode into
     //              pulPCMSize  size of the PCM buffer.  It will contain the
-    //                          number of PCM bytes prodced upon return.
+    //                          number of PCM bytes produced upon return.
     ///////////////////////////////////////////////////////////////////////////
     void    DecodeFrame_v(unsigned char *pSource,
               	          unsigned long *pulSize,

--- a/src/libtinysoundfont/tsf.h
+++ b/src/libtinysoundfont/tsf.h
@@ -42,6 +42,16 @@
 
 */
 
+// ESP32 as of 3.x has a compiler bug in this section, with the G++ generated assembly
+// being illegal.  There's nothing wrong with the code here, it just looks like an
+// Xtensa backend issue.  Until that's fixed, no MIDI for you!
+///home/earle/Arduino/libraries/ESP8266Audio/src/libtinysoundfont/tsf.h: In function 'void tsf_channel_midi_control(tsf*, int, int, int)':
+// /home/earle/Arduino/libraries/ESP8266Audio/src/libtinysoundfont/tsf.h:2101:1: error: insn does not satisfy its constraints:
+//  2101 | }
+//       | ^
+
+#if !defined(ESP32)
+
 #ifndef TSF_INCLUDE_TSF_INL
 #define TSF_INCLUDE_TSF_INL
 
@@ -2145,3 +2155,5 @@ TSFDEF float tsf_channel_get_tuning(tsf* f, int channel)
 #endif
 
 #endif //TSF_IMPLEMENTATION
+
+#endif // ! ESP32


### PR DESCRIPTION
Implement the renamed network client and other API changes when built under the 3.x branch of the Arduino ESP32 core.

Disable building TSF on the ESP32, the Xtensa G++ backend bug is still there.

Minimal changes to get I2S to build under new IDF.  Deprecated but not removed, so warnings are expected but should not be fatal in use.

Fixes #683