### PR TITLE
Fix GCC14-detected warnings

### DIFF
--- a/src/AudioOutputMixer.cpp
+++ b/src/AudioOutputMixer.cpp
@@ -71,8 +71,8 @@ bool AudioOutputMixerStub::stop()
 AudioOutputMixer::AudioOutputMixer(int buffSizeSamples, AudioOutput *dest) : AudioOutput()
 {
   buffSize = buffSizeSamples;
-  leftAccum = (int32_t*)calloc(sizeof(int32_t), buffSize);
-  rightAccum = (int32_t*)calloc(sizeof(int32_t), buffSize);
+  leftAccum = (int32_t*)calloc(buffSize, sizeof(int32_t));
+  rightAccum = (int32_t*)calloc(buffSize, sizeof(int32_t));
   for (int i=0; i<maxStubs; i++) {
     stubAllocated[i] = false;
     stubRunning[i] = false;

--- a/src/libhelix-aac/decelmnt.c
+++ b/src/libhelix-aac/decelmnt.c
@@ -258,10 +258,10 @@ int DecodeProgramConfigElement(ProgConfigElement *pce, BitStreamInfo *bsi)
 		pce->bce[i] |= GetBits(bsi, 4);			/* tag select */
 	}
 
-	for (i = 0; i < pce->numLCE; i++)
+	for (i = 0; i < pce->numLCE && i < MAX_NUM_LCE; i++)
 		pce->lce[i] = GetBits(bsi, 4);			/* tag select */
 
-	for (i = 0; i < pce->numADE; i++)
+	for (i = 0; i < pce->numADE && i < MAX_NUM_ADE; i++)
 		pce->ade[i] = GetBits(bsi, 4);			/* tag select */
 
 	for (i = 0; i < pce->numCCE; i++) {

--- a/src/libhelix-aac/noiseless.c
+++ b/src/libhelix-aac/noiseless.c
@@ -253,7 +253,7 @@ static int DecodeOneScaleFactor(BitStreamInfo *bsi)
 
 	pi->numPulse = GetBits(bsi, 2) + 1;		/* add 1 here */
 	pi->startSFB = GetBits(bsi, 6);
-	for (i = 0; i < pi->numPulse; i++) {
+	for (i = 0; i < pi->numPulse && i < MAX_PULSES; i++) {
 		pi->offset[i] = GetBits(bsi, 5);
 		pi->amp[i] = GetBits(bsi, 4);
 	}

--- a/src/libhelix-aac/sbrside.c
+++ b/src/libhelix-aac/sbrside.c
@@ -195,7 +195,7 @@ static void UnpackSBRGrid(BitStreamInfo *bsi, SBRHeader *sbrHdr, SBRGrid *sbrGri
 		absBorder = GetBits(bsi, 2) + NUM_TIME_SLOTS;
 		numRelBorder = GetBits(bsi, 2);
 		sbrGrid->numEnv = numRelBorder + 1;
-		for (rel = 0; rel < numRelBorder; rel++)
+		for (rel = 0; rel < numRelBorder && rel < 3; rel++)
 			relBorder[rel] = 2*GetBits(bsi, 2) + 2;
 
 		pBits = cLog2[sbrGrid->numEnv + 1];
@@ -221,13 +221,13 @@ static void UnpackSBRGrid(BitStreamInfo *bsi, SBRHeader *sbrHdr, SBRGrid *sbrGri
 		absBorder = GetBits(bsi, 2);
 		numRelBorder = GetBits(bsi, 2);
 		sbrGrid->numEnv = numRelBorder + 1;
-		for (rel = 0; rel < numRelBorder; rel++)
+		for (rel = 0; rel < numRelBorder && rel < 3; rel++)
 			relBorder[rel] = 2*GetBits(bsi, 2) + 2;
 
 		pBits = cLog2[sbrGrid->numEnv + 1];
 		sbrGrid->pointer = GetBits(bsi, pBits);
 
-		for (env = 0; env < sbrGrid->numEnv; env++)
+		for (env = 0; env < sbrGrid->numEnv && env < MAX_NUM_ENV; env++)
 			sbrGrid->freqRes[env] = GetBits(bsi, 1);
 
 		absBordLead =  absBorder;
@@ -253,16 +253,16 @@ static void UnpackSBRGrid(BitStreamInfo *bsi, SBRHeader *sbrHdr, SBRGrid *sbrGri
 		sbrGrid->numEnv = numRelBorder0 + numRelBorder1 + 1;
 		ASSERT(sbrGrid->numEnv <= 5);
 
-		for (rel = 0; rel < numRelBorder0; rel++)
+		for (rel = 0; rel < numRelBorder0 && rel < 3; rel++)
 			relBorder0[rel] = 2*GetBits(bsi, 2) + 2;
 
-		for (rel = 0; rel < numRelBorder1; rel++)
+		for (rel = 0; rel < numRelBorder1 && rel < 3; rel++)
 			relBorder1[rel] = 2*GetBits(bsi, 2) + 2;
 
 		pBits = cLog2[numRelBorder0 + numRelBorder1 + 2];
 		sbrGrid->pointer = GetBits(bsi, pBits);
 
-		for (env = 0; env < sbrGrid->numEnv; env++)
+		for (env = 0; env < sbrGrid->numEnv && env < MAX_NUM_ENV; env++)
 			sbrGrid->freqRes[env] = GetBits(bsi, 1);
 
 		numRelLead =  numRelBorder0;


### PR DESCRIPTION
* Ensure AAC read-in doesn't overflow internal structures when the file is corrupted/illegal.
* Fix pedantic GCC14 warnings on calloc order
