### PR TITLE
Add support for MIPS CPU architecture

### DIFF
--- a/src/libhelix-aac/aacdec.h
+++ b/src/libhelix-aac/aacdec.h
@@ -64,6 +64,8 @@
 #
 #elif defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__))
 #
+#elif defined(__GNUC__) && (defined(__mips__) || defined(__MIPS__))
+#
 #elif defined(_OPENWAVE_SIMULATOR) || defined(_OPENWAVE_ARMULATOR)
 #
 #elif defined(_SOLARIS) && !defined(__GNUC__)

--- a/src/libhelix-aac/assembly.h
+++ b/src/libhelix-aac/assembly.h
@@ -500,7 +500,7 @@ static __inline Word64 MADD64(Word64 sum64, int x, int y)
 	return sum64;
 }
 
-#elif defined(ARDUINO) || defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__)) || (defined (_SOLARIS) && !defined (__GNUC__) && !defined (_SOLARISX86))
+#elif defined(ARDUINO) || defined(__GNUC__) && (defined(__mips__) || defined(__MIPS__)) || defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__)) || (defined (_SOLARIS) && !defined (__GNUC__) && !defined (_SOLARISX86))
 
 typedef long long Word64;
 


### PR DESCRIPTION
The [Thingino open source camera project](https://thingino.com) would like to use ESP8266Audio for AAC decoding. The Ingenic cameras use the MIPS CPU architecture and this patch gets the project to compile.