### PR TITLE
Speed up AAC decode by ~20% on Pico/ESP32

### DIFF
--- a/src/libhelix-aac/fft.c
+++ b/src/libhelix-aac/fft.c
@@ -78,11 +78,11 @@ static const int nfftlog2Tab[NUM_FFT_SIZES] PROGMEM = {6, 9};
     part1 = inout + (1 << nbits);
 
 #ifdef ESP8266
-     while ((a = pgm_read_byte(tab++)) != 0) {
-         b = pgm_read_byte(tab++);
+    while ((a = pgm_read_byte(tab++)) != 0) {
+        b = pgm_read_byte(tab++);
 #else
-     while ((a = *(tab++)) != 0) {
-         b = *(tab++);
+    while ((a = *(tab++)) != 0) {
+        b = *(tab++);
 #endif
 
         swapcplx(part0[4 * a + 0], part0[4 * b + 0]);	/* 0xxx0 <-> 0yyy0 */

--- a/src/libhelix-aac/fft.c
+++ b/src/libhelix-aac/fft.c
@@ -1,3 +1,4 @@
+#pragma GCC optimize ("O3")
 /* ***** BEGIN LICENSE BLOCK *****
     Source last modified: $Id: fft.c,v 1.1 2005/02/26 01:47:34 jrecker Exp $
 
@@ -76,8 +77,13 @@ static const int nfftlog2Tab[NUM_FFT_SIZES] PROGMEM = {6, 9};
     part0 = inout;
     part1 = inout + (1 << nbits);
 
-    while ((a = pgm_read_byte(tab++)) != 0) {
-        b = pgm_read_byte(tab++);
+#ifdef ESP8266
+     while ((a = pgm_read_byte(tab++)) != 0) {
+         b = pgm_read_byte(tab++);
+#else
+     while ((a = *(tab++)) != 0) {
+         b = *(tab++);
+#endif
 
         swapcplx(part0[4 * a + 0], part0[4 * b + 0]);	/* 0xxx0 <-> 0yyy0 */
         swapcplx(part0[4 * a + 2], part1[4 * b + 0]);	/* 0xxx1 <-> 1yyy0 */
@@ -87,8 +93,11 @@ static const int nfftlog2Tab[NUM_FFT_SIZES] PROGMEM = {6, 9};
 
     do {
         swapcplx(part0[4 * a + 2], part1[4 * a + 0]);	/* 0xxx1 <-> 1xxx0 */
+#ifdef ESP8266
     } while ((a = pgm_read_byte(tab++)) != 0);
-
+#else
+    } while ((a = *(tab++)) != 0);
+#endif
 
 }
 

--- a/src/libhelix-aac/huffmanaac.c
+++ b/src/libhelix-aac/huffmanaac.c
@@ -84,7 +84,11 @@
         t = (bitBuf >> shift) - start;
     } while (t >= count);
 
+#ifdef ESP8266
     *val = (signed int)pgm_read_word(&map[t]);
+#else
+    *val = map[t];
+#endif
     return (countPtr - huffTabInfo->count);
 }
 

--- a/src/libhelix-aac/sbr.h
+++ b/src/libhelix-aac/sbr.h
@@ -179,7 +179,11 @@ enum {
 
 typedef struct _HuffInfo {
     int maxBits;							/* number of bits in longest codeword */
+#ifdef ESP8266
     unsigned /*char*/ int count[MAX_HUFF_BITS];		/* count[i] = number of codes with length i+1 bits */
+#else
+    unsigned char count[MAX_HUFF_BITS];		/* count[i] = number of codes with length i+1 bits */
+#endif
     int offset;								/* offset into symbol table */
 } HuffInfo;
 
@@ -374,7 +378,11 @@ extern const unsigned char k0Tab[NUM_SAMPLE_RATES_SBR][16];
 extern const unsigned char k2Tab[NUM_SAMPLE_RATES_SBR][14];
 extern const unsigned char goalSBTab[NUM_SAMPLE_RATES_SBR];
 extern const HuffInfo huffTabSBRInfo[10];
+#ifdef ESP8266
 extern const signed int /*short*/ huffTabSBR[604];
+#else
+extern const signed short huffTabSBR[604];
+#endif
 extern const int log2Tab[65];
 extern const int noiseTab[512 * 2];
 extern const int cTabA[165];

--- a/src/libhelix-aac/sbrhuff.c
+++ b/src/libhelix-aac/sbrhuff.c
@@ -1,3 +1,4 @@
+#pragma GCC optimize ("O3")
 /* ***** BEGIN LICENSE BLOCK *****
     Source last modified: $Id: sbrhuff.c,v 1.1 2005/02/26 01:47:35 jrecker Exp $
 
@@ -65,10 +66,19 @@
                   if there are no codes at nBits, then we just keep << 1 each time
                     (since count[nBits] = 0)
  **************************************************************************************/
+#ifdef ESP8266
 static int DecodeHuffmanScalar(const signed /*short*/ int *huffTab, const HuffInfo *huffTabInfo, unsigned int bitBuf, signed int *val) {
+#else
+static int DecodeHuffmanScalar(const signed short int *huffTab, const HuffInfo *huffTabInfo, unsigned int bitBuf, signed int *val) {
+#endif
     unsigned int count, start, shift, t;
+#ifdef ESP8266
     const unsigned int /*char*/ *countPtr;
     const signed int /*short*/ *map;
+#else
+    const unsigned char *countPtr;
+    const signed short *map;
+#endif
 
     map = huffTab + huffTabInfo->offset;
     countPtr = huffTabInfo->count;

--- a/src/libhelix-aac/sbrtabs.c
+++ b/src/libhelix-aac/sbrtabs.c
@@ -1,3 +1,4 @@
+#pragma GCC optimize ("O3")
 /* ***** BEGIN LICENSE BLOCK *****
     Source last modified: $Id: sbrtabs.c,v 1.1 2005/02/26 01:47:35 jrecker Exp $
 
@@ -44,6 +45,12 @@
  **************************************************************************************/
 
 #include "sbr.h"
+
+#if defined(PICO_RP2040) || defined(PICO_RP2350)
+#define DPROGMEM __attribute__(( section(".time_critical.data") ))
+#else
+#define DPROGMEM PROGMEM
+#endif
 
 /*  k0Tab[sampRateIdx][k] = k0 = startMin + offset(bs_start_freq) for given sample rate (4.6.18.3.2.1)
     downsampled (single-rate) SBR not currently supported
@@ -97,7 +104,11 @@ const HuffInfo huffTabSBRInfo[10] PROGMEM = {
 };
 
 /* Huffman tables from appendix 4.A.6.1, includes offset of -LAV[i] for table i */
+#ifdef ESP8266
 const signed int /*short*/ huffTabSBR[604] PROGMEM = {
+#else
+const signed short huffTabSBR[604] PROGMEM = {
+#endif
     /* SBR table sbr_tenv15 [121] (signed) */
     0,   -1,    1,   -2,    2,   -3,    3,   -4,    4,   -5,    5,   -6,    6,   -7,    7,   -8,
     -9,    8,  -10,    9,  -11,   10,  -12,  -13,   11,  -14,   12,  -15,  -16,   13,  -19,  -18,

--- a/src/libhelix-aac/trigtabs.c
+++ b/src/libhelix-aac/trigtabs.c
@@ -48,7 +48,13 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
-const int cos4sin4tabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+#if defined(PICO_RP2040) || defined(PICO_RP2350)
+#define DPROGMEM __attribute__(( section(".time_critical.data") ))
+#else
+#define DPROGMEM PROGMEM
+#endif
+
+const int cos4sin4tabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  PreMultiply() tables
     format = Q30 * 2^[-7, -10] for nmdct = [128, 1024]
@@ -65,7 +71,7 @@ const int cos4sin4tabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
      x = invM * sin(angle);
     }
 */
-const int cos4sin4tab[128 + 1024] PROGMEM = {
+const int cos4sin4tab[128 + 1024] DPROGMEM = {
     /* 128 - format = Q30 * 2^-7 */
     0xbf9bc731, 0xff9b783c, 0xbed5332c, 0xc002c697, 0xbe112251, 0xfe096c8d, 0xbd4f9c30, 0xc00f1c4a,
     0xbc90a83f, 0xfc77ae5e, 0xbbd44dd9, 0xc0254e27, 0xbb1a9443, 0xfae67ba2, 0xba6382a6, 0xc04558c0,
@@ -225,7 +231,7 @@ const int cos4sin4tab[128 + 1024] PROGMEM = {
      x = sin(angle);
     }
 */
-const int cos1sin1tab[514] PROGMEM = {
+const int cos1sin1tab[514] DPROGMEM = {
     /* format = Q30 */
     0x40000000, 0x00000000, 0x40323034, 0x003243f1, 0x406438cf, 0x006487c4, 0x409619b2, 0x0096cb58,
     0x40c7d2bd, 0x00c90e90, 0x40f963d3, 0x00fb514b, 0x412accd4, 0x012d936c, 0x415c0da3, 0x015fd4d2,
@@ -294,7 +300,7 @@ const int cos1sin1tab[514] PROGMEM = {
     0x5a82799a, 0x2d413ccd,
 };
 
-const int sinWindowOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+const int sinWindowOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  Synthesis window - SIN
     format = Q31 for nmdct = [128, 1024]
@@ -457,7 +463,7 @@ const int sinWindow[128 + 1024] PROGMEM = {
     0x5a05bdae, 0x5afe8a8b, 0x5a29727b, 0x5adb297d, 0x5a4d1960, 0x5ab7ba6c, 0x5a70b258, 0x5a943d5e,
 };
 
-const int kbdWindowOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 128};
+const int kbdWindowOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 128};
 
 /*  Synthesis window - KBD
     format = Q31 for nmdct = [128, 1024]
@@ -623,9 +629,9 @@ const int kbdWindow[128 + 1024] PROGMEM = {
 
 /* bit reverse tables for FFT */
 
-const int bitrevtabOffset[NUM_IMDCT_SIZES] PROGMEM = {0, 17};
+const int bitrevtabOffset[NUM_IMDCT_SIZES] DPROGMEM = {0, 17};
 
-const unsigned char bitrevtab[17 + 129] PROGMEM = {
+const unsigned char bitrevtab[17 + 129] DPROGMEM = {
     /* nfft = 64 */
     0x01, 0x08, 0x02, 0x04, 0x03, 0x0c, 0x05, 0x0a, 0x07, 0x0e, 0x0b, 0x0d, 0x00, 0x06, 0x09, 0x0f,
     0x00,
@@ -643,7 +649,7 @@ const unsigned char bitrevtab[17 + 129] PROGMEM = {
 
 };
 
-const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 0x5f};
+const unsigned char uniqueIDTab[8] DPROGMEM = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 0x5f};
 
 /*  Twiddle tables for FFT
     format = Q30
@@ -685,7 +691,7 @@ const unsigned char uniqueIDTab[8] = {0x5f, 0x4b, 0x43, 0x5f, 0x5f, 0x4a, 0x52, 
      }
     }
 */
-const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] PROGMEM = {
+const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] DPROGMEM = {
     0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x539eba45, 0xe7821d59,
     0x4b418bbe, 0xf383a3e2, 0x58c542c5, 0xdc71898d, 0x5a82799a, 0xd2bec333, 0x539eba45, 0xe7821d59,
     0x539eba45, 0xc4df2862, 0x539eba45, 0xc4df2862, 0x58c542c5, 0xdc71898d, 0x3248d382, 0xc13ad060,
@@ -816,7 +822,7 @@ const int twidTabOdd[8 * 6 + 32 * 6 + 128 * 6] PROGMEM = {
     0xbb771c81, 0x3fd39b5a, 0xc197049e, 0xfe6deaa1, 0x40c7d2bd, 0xc0013bd3, 0xbdb00d71, 0x3ff4e5e0,
 };
 
-const int twidTabEven[4 * 6 + 16 * 6 + 64 * 6] PROGMEM = {
+const int twidTabEven[4 * 6 + 16 * 6 + 64 * 6] DPROGMEM = {
     0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x40000000, 0x00000000, 0x5a82799a, 0xd2bec333,
     0x539eba45, 0xe7821d59, 0x539eba45, 0xc4df2862, 0x40000000, 0xc0000000, 0x5a82799a, 0xd2bec333,
     0x00000000, 0xd2bec333, 0x00000000, 0xd2bec333, 0x539eba45, 0xc4df2862, 0xac6145bb, 0x187de2a7,

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -20,7 +20,7 @@ libhelix_aac=../../src/libhelix-aac/decelmnt.c ../../src/libhelix-aac/dct4.c ../
 ../../src/libhelix-aac/trigtabs.c ../../src/libhelix-aac/fft.c ../../src/libhelix-aac/pns.c ../../src/libhelix-aac/sbrfreq.c \
 ../../src/libhelix-aac/sbrside.c ../../src/libhelix-aac/sbrhfadj.c ../../src/libhelix-aac/buffers.c ../../src/libhelix-aac/bitstream.c \
 ../../src/libhelix-aac/noiseless.c ../../src/libhelix-aac/imdct.c ../../src/libhelix-aac/aacdec.c ../../src/libhelix-aac/sbrhfgen.c \
-../../src/libhelix-aac/sbrqmf.c ../../src/libhelix-aac/huffman.c ../../src/libhelix-aac/sbr.c ../../src/libhelix-aac/sbrimdct.c
+../../src/libhelix-aac/sbrqmf.c ../../src/libhelix-aac/huffmanaac.c ../../src/libhelix-aac/sbr.c ../../src/libhelix-aac/sbrimdct.c
 
 libflac=../../src/libflac/md5.c ../../src/libflac/window.c ../../src/libflac/memory.c ../../src/libflac/cpu.c ../../src/libflac/fixed.c \
 ../../src/libflac/format.c ../../src/libflac/lpc.c ../../src/libflac/crc.c ../../src/libflac/bitreader.c ../../src/libflac/bitmath.c \


### PR DESCRIPTION
Import the optimized (well...de-un-optimized) version of libhelix from BackgroundAudio for about a 20% speedup on the Pico for AAC decode.