### PR TITLE
Scan MP3 for header, avoid multiple burst errors

### DIFF
--- a/examples/MixerSample/MixerSample.ino
+++ b/examples/MixerSample/MixerSample.ino
@@ -1,16 +1,8 @@
 #include <Arduino.h>
-
-#if defined(ARDUINO_ARCH_RP2040)
-#define WIFI_OFF
-class __x {
-  public: __x() {};
-    void mode() {};
-};
-__x WiFi;
-#elif defined(ESP32)
-#include <WiFi.h>
-#else
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
 #endif
 
 #include "AudioFileSourcePROGMEM.h"
@@ -79,6 +71,4 @@ void loop() {
       }
     }
   }
-
 }
-

--- a/examples/PlayAACFromPROGMEM/PlayAACFromPROGMEM.ino
+++ b/examples/PlayAACFromPROGMEM/PlayAACFromPROGMEM.ino
@@ -19,7 +19,6 @@ void setup() {
   aac->begin(in, out);
 }
 
-
 void loop() {
   if (aac->isRunning()) {
     aac->loop();
@@ -28,4 +27,3 @@ void loop() {
     delay(1000);
   }
 }
-

--- a/examples/PlayFLACFromPROGMEMToDAC/PlayFLACFromPROGMEMToDAC.ino
+++ b/examples/PlayFLACFromPROGMEMToDAC/PlayFLACFromPROGMEMToDAC.ino
@@ -30,4 +30,3 @@ void loop() {
     delay(1000);
   }
 }
-

--- a/examples/PlayMIDIFromLittleFS/PlayMIDIFromLittleFS.ino
+++ b/examples/PlayMIDIFromLittleFS/PlayMIDIFromLittleFS.ino
@@ -1,20 +1,8 @@
 #include <Arduino.h>
-#ifdef ESP32
-void setup() {
-  Serial.begin(115200);
-  Serial.printf("ERROR - ESP32 does not support LittleFS\n");
-}
-void loop() {}
-#else
-#if defined(ARDUINO_ARCH_RP2040)
-#define WIFI_OFF
-class __x {
-  public: __x() {};
-    void mode() {};
-};
-__x WiFi;
-#else
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
 #endif
 #include <AudioOutputI2S.h>
 #include <AudioGeneratorMIDI.h>
@@ -56,5 +44,3 @@ void loop() {
     delay(1000);
   }
 }
-
-#endif

--- a/examples/PlayMIDIFromLittleFS/PlayMIDIFromLittleFS.ino
+++ b/examples/PlayMIDIFromLittleFS/PlayMIDIFromLittleFS.ino
@@ -1,3 +1,8 @@
+#if (defined(ESP32) && (__GNUC__ >= 8) && (__XTENSA__))
+// GCC compiler bug for the Xtensa ESP32s, no MIDI for you. :(
+void setup() {}
+void loop() {}
+#else
 #include <Arduino.h>
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
@@ -44,3 +49,5 @@ void loop() {
     delay(1000);
   }
 }
+
+#endif

--- a/examples/PlayMODFromPROGMEMToDAC/PlayMODFromPROGMEMToDAC.ino
+++ b/examples/PlayMODFromPROGMEMToDAC/PlayMODFromPROGMEMToDAC.ino
@@ -2,17 +2,11 @@
 #include "AudioFileSourcePROGMEM.h"
 #include "AudioGeneratorMOD.h"
 #include "AudioOutputI2S.h"
-#if defined(ARDUINO_ARCH_RP2040)
-#define WIFI_OFF
-class __x {
-  public: __x() {};
-    void mode() {};
-};
-__x WiFi;
-#elif defined(ESP32)
-#include <WiFi.h>
-#else
+
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
 #endif
 
 // enigma.mod sample from the mod archive: https://modarchive.org/index.php?request=view_by_moduleid&query=42146
@@ -48,4 +42,3 @@ void loop() {
     delay(1000);
   }
 }
-

--- a/examples/TalkingClockI2S/TalkingClockI2S.ino
+++ b/examples/TalkingClockI2S/TalkingClockI2S.ino
@@ -4,15 +4,10 @@
 
 #include <Arduino.h>
 
-#if defined(ARDUINO_ARCH_RP2040)
-void setup() {}
-void loop() {}
-#else
-
-#if defined(ESP32)
-#include <WiFi.h>
-#else
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
 #endif
 
 #include <time.h>
@@ -194,4 +189,3 @@ void loop() {
   sayTime(tmstruct.tm_hour, tmstruct.tm_min, talkie);
   delay(1000);
 }
-#endif

--- a/examples/TalkingClockI2S/TalkingClockI2S.ino
+++ b/examples/TalkingClockI2S/TalkingClockI2S.ino
@@ -163,7 +163,16 @@ void setup() {
   Serial.println("IP address: ");
   Serial.println(WiFi.localIP());
   Serial.println("Contacting Time Server");
+#if defined(ARDUINO_ARCH_RP2040)
+  NTP.begin("pool.ntp.org", "time.nist.gov");
+  Serial.print("Waiting for NTP time sync: ");
+  NTP.waitSet([]() {
+    Serial.print(".");
+  });
+  Serial.println("");
+#else
   configTime(3600 * timezone, daysavetime * 3600, "time.nist.gov", "0.pool.ntp.org", "1.pool.ntp.org");
+#endif
   struct tm tmstruct ;
   do {
     tmstruct.tm_year = 0;

--- a/examples/WebRadio/WebRadio.ino
+++ b/examples/WebRadio/WebRadio.ino
@@ -126,13 +126,13 @@ Change URL: <input type="text" name="url">
 </body>)KEWL";
 
 void HandleIndex(WiFiClient *client) {
-  char buff[std::max(sizeof(BODY) + sizeof(title) + sizeof(status) + sizeof(url) + 3 * 2, sizeof(BODY))];
+  char buff[std::max(sizeof(BODY) + sizeof(title) + sizeof(status) + sizeof(url) + 3 * 2, sizeof(HEAD))];
 
   Serial.printf_P(PSTR("Sending INDEX...Free mem=%d\n"), MOBO.getFreeHeap());
   WebHeaders(client, NULL);
   WebPrintf(client, DOCTYPE);
   client->write("<html>", 6);
-  sprintf_P(buff, "%s", HEAD);
+  strcpy_P(buff, HEAD);
   client->write(buff, strlen(buff));
   sprintf_P(buff, BODY, title, volume, volume, status, url);
   client->write(buff, strlen(buff));

--- a/examples/WebRadio/WebRadio.ino
+++ b/examples/WebRadio/WebRadio.ino
@@ -19,24 +19,29 @@
 */
 
 #include <Arduino.h>
-#if defined(ARDUINO_ARCH_RP2040)
-void setup() {}
-void loop() {}
-#else
 
 // ESP8266 server.available() is now server.accept()
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
-#if defined(ESP32)
-#include <WiFi.h>
-#else
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
 #endif
+
 #include "AudioFileSourceICYStream.h"
 #include "AudioFileSourceBuffer.h"
 #include "AudioGeneratorMP3.h"
 #include "AudioGeneratorAAC.h"
+#if defined(ARDUINO_ARCH_RP2040)
+#include "AudioOutputPWM.h"
+#define MOBO rp2040
+AudioOutputPWM *out = NULL;
+#else
 #include "AudioOutputI2S.h"
+AudioOutputI2S *out = NULL;
+#define MOBO ESP
+#endif
 #include <EEPROM.h>
 
 // Custom web server that doesn't need much RAM
@@ -58,7 +63,6 @@ WiFiServer server(80);
 AudioGenerator *decoder = NULL;
 AudioFileSourceICYStream *file = NULL;
 AudioFileSourceBuffer *buff = NULL;
-AudioOutputI2S *out = NULL;
 
 int volume = 100;
 char title[64];
@@ -122,17 +126,18 @@ Change URL: <input type="text" name="url">
 </body>)KEWL";
 
 void HandleIndex(WiFiClient *client) {
-  char buff[sizeof(BODY) + sizeof(title) + sizeof(status) + sizeof(url) + 3 * 2];
+  char buff[std::max(sizeof(BODY) + sizeof(title) + sizeof(status) + sizeof(url) + 3 * 2, sizeof(BODY))];
 
-  Serial.printf_P(PSTR("Sending INDEX...Free mem=%d\n"), ESP.getFreeHeap());
+  Serial.printf_P(PSTR("Sending INDEX...Free mem=%d\n"), MOBO.getFreeHeap());
   WebHeaders(client, NULL);
   WebPrintf(client, DOCTYPE);
-  client->write_P(PSTR("<html>"), 6);
-  client->write_P(HEAD, strlen_P(HEAD));
+  client->write("<html>", 6);
+  sprintf_P(buff, "%s", HEAD);
+  client->write(buff, strlen(buff));
   sprintf_P(buff, BODY, title, volume, volume, status, url);
   client->write(buff, strlen(buff));
-  client->write_P(PSTR("</html>"), 7);
-  Serial.printf_P(PSTR("Sent INDEX...Free mem=%d\n"), ESP.getFreeHeap());
+  client->write("</html>", 7);
+  Serial.printf_P(PSTR("Sent INDEX...Free mem=%d\n"), MOBO.getFreeHeap());
 }
 
 void HandleStatus(WiFiClient *client) {
@@ -259,7 +264,10 @@ void setup() {
 
   Serial.begin(115200);
 
-  delay(1000);
+  delay(3000);
+#ifndef ESP8266
+  Serial.printf_P(PSTR("Consider using BackgroundAudio instead, it is much faster and stable.\nhttps://github.com/earlephilhower/BackgroundAudio\n"));
+#endif
   Serial.printf_P(PSTR("Connecting to WiFi\n"));
 
   WiFi.disconnect();
@@ -288,7 +296,11 @@ void setup() {
   audioLogger = &Serial;
   file = NULL;
   buff = NULL;
+#if defined(ARDUINO_ARCH_RP2040)
+  out = new AudioOutputPWM(44100, 0);
+#else
   out = new AudioOutputI2S();
+#endif
   decoder = NULL;
 
   LoadSettings();
@@ -299,9 +311,9 @@ void StartNewURL() {
 
   newUrl = false;
   // Stop and free existing ones
-  Serial.printf_P(PSTR("Before stop...Free mem=%d\n"), ESP.getFreeHeap());
+  Serial.printf_P(PSTR("Before stop...Free mem=%d\n"), MOBO.getFreeHeap());
   StopPlaying();
-  Serial.printf_P(PSTR("After stop...Free mem=%d\n"), ESP.getFreeHeap());
+  Serial.printf_P(PSTR("After stop...Free mem=%d\n"), MOBO.getFreeHeap());
   SaveSettings();
   Serial.printf_P(PSTR("Saved settings\n"));
 
@@ -388,7 +400,7 @@ void loop() {
   static int lastms = 0;
   if (millis() - lastms > 1000) {
     lastms = millis();
-    Serial.printf_P(PSTR("Running for %d seconds%c...Free mem=%d\n"), lastms / 1000, !decoder ? ' ' : (decoder->isRunning() ? '*' : ' '), ESP.getFreeHeap());
+    Serial.printf_P(PSTR("Running for %d seconds%c...Free mem=%d\n"), lastms / 1000, !decoder ? ' ' : (decoder->isRunning() ? '*' : ' '), MOBO.getFreeHeap());
   }
 
   if (retryms && millis() - retryms > 0) {
@@ -436,5 +448,3 @@ void loop() {
     client.stop();
   }
 }
-
-#endif

--- a/examples/WebRadio/web.cpp
+++ b/examples/WebRadio/web.cpp
@@ -19,13 +19,10 @@
 */
 
 #include <Arduino.h>
-#if defined(ARDUINO_ARCH_RP2040)
-// Nothing here
+#ifdef ESP8266
+#include <ESP8266WiFi.h>
 #else
-#ifdef ESP32
-    #include <WiFi.h>
-#else
-    #include <ESP8266WiFi.h>
+#include <WiFi.h>
 #endif
 #include "web.h"
 
@@ -311,4 +308,3 @@ void Read4Int(char *str, byte *p)
   str += ParseInt(str, &i); p[2] = i; if (*str) str++;
   str += ParseInt(str, &i); p[3] = i;
 }
-#endif

--- a/src/AudioFileSource.h
+++ b/src/AudioFileSource.h
@@ -74,4 +74,3 @@ protected:
 };
 
 #endif
-

--- a/src/AudioFileSourceHTTPStream.cpp
+++ b/src/AudioFileSourceHTTPStream.cpp
@@ -18,8 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(ESP32) || defined(ESP8266)
-
 #include "AudioFileSourceHTTPStream.h"
 
 AudioFileSourceHTTPStream::AudioFileSourceHTTPStream() {
@@ -156,5 +154,3 @@ uint32_t AudioFileSourceHTTPStream::getSize() {
 uint32_t AudioFileSourceHTTPStream::getPos() {
     return pos;
 }
-
-#endif

--- a/src/AudioFileSourceHTTPStream.h
+++ b/src/AudioFileSourceHTTPStream.h
@@ -18,14 +18,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(ESP32) || defined(ESP8266)
 #pragma once
 
 #include <Arduino.h>
-#ifdef ESP32
-#include <HTTPClient.h>
-#else
+#ifdef ESP8266
 #include <ESP8266HTTPClient.h>
+#else
+#include <HTTPClient.h>
 #endif
 #include "AudioFileSource.h"
 
@@ -70,7 +69,3 @@ private:
     int reconnectDelayMs;
     char saveURL[128];
 };
-
-
-#endif
-

--- a/src/AudioFileSourceICYStream.cpp
+++ b/src/AudioFileSourceICYStream.cpp
@@ -18,8 +18,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(ESP32) || defined(ESP8266)
-
 #ifdef _GNU_SOURCE
 #undef _GNU_SOURCE
 #endif
@@ -260,5 +258,3 @@ retry:
     icyByteCount += ret;
     return read;
 }
-
-#endif

--- a/src/AudioFileSourceICYStream.h
+++ b/src/AudioFileSourceICYStream.h
@@ -18,14 +18,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(ESP32) || defined(ESP8266)
 #pragma once
 
 #include <Arduino.h>
-#ifdef ESP32
-#include <HTTPClient.h>
-#else
+#ifdef ESP8266
 #include <ESP8266HTTPClient.h>
+#else
+#include <HTTPClient.h>
 #endif
 
 #include "AudioFileSourceHTTPStream.h"
@@ -43,5 +42,3 @@ private:
     int icyMetaInt;
     int icyByteCount;
 };
-
-#endif

--- a/src/AudioOutputPWM.cpp
+++ b/src/AudioOutputPWM.cpp
@@ -69,6 +69,7 @@ bool AudioOutputPWM::SetOutputModeMono(bool mono) {
 bool AudioOutputPWM::begin() {
     if (!pwmOn) {
         pwm.setPin(doutPin);
+        pwm.setBuffers(8, 128);
         pwm.begin(hertz);
     }
     pwmOn = true;

--- a/tests/build-ci.sh
+++ b/tests/build-ci.sh
@@ -21,7 +21,11 @@ while [ $(echo $sketches | wc -w) -gt 0 ]; do
     mv -f "$outdir"/*.elf .
     echo "::endgroup::"
     # Shift out 5
-    sketches=$(echo $sketches | cut -f6- -d " ")
+    if [  $(echo $sketches | wc -w) -gt 5 ]; then
+        sketches=$(echo $sketches | cut -f6- -d " ")
+    else
+        sketches=""
+    fi
 done
 
 echo "::group::Final Sizes"

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -101,8 +101,20 @@ EOL
     echo $(( 1 - $? ))
 }
 
+# ESP8266 CI infra
 function skip_sketch()
 {
+    local sketch=$1
+    local sketchname=$2
+    local sketchdir=$3
+    local sketchdirname=$4
+
+    if [[ "${sketchdirname}.ino" != "$sketchname" ]]; then
+        echo "Skipping $sketch (not the main sketch file)"
+    fi
+    if skip_ino "$sketch" || [[ -f "$sketchdir/.test.skip" ]]; then
+        echo "Skipping $sketch"
+    fi
 }
 
 if [ "$BUILD_MOD" == "" ]; then

--- a/tests/common.sh
+++ b/tests/common.sh
@@ -101,7 +101,9 @@ EOL
     echo $(( 1 - $? ))
 }
 
-
+function skip_sketch()
+{
+}
 
 if [ "$BUILD_MOD" == "" ]; then
     export BUILD_MOD=1


### PR DESCRIPTION
MP3 comes in chunks of encoded data started by a header sequence. Scan for it in the decoder and only pass in data that starts with this header to avoid the burst errors

Avoids a avalance of `lost synchronization` error reports when there is a file error.

Also enable some of the web sources on the RP2040/RP2350