### PR TITLE
Potential fix for code scanning alert no. 9: Array offset used before range check

### DIFF
--- a/src/libtinysoundfont/tsf.h
+++ b/src/libtinysoundfont/tsf.h
@@ -1871,7 +1871,7 @@ TSFDEF int tsf_get_presetcount(const tsf* f) {
 }
 
 TSFDEF const char* tsf_get_presetname(const tsf* f, int preset) {
-    if (f->presets[preset].regions == NULL && preset >= 0 && preset < f->presetNum) {
+    if (preset >= 0 && preset < f->presetNum && f->presets[preset].regions == NULL) {
         tsf_load_preset(f, f->hydra, preset);
     }
     return (preset < 0 || preset >= f->presetNum ? TSF_NULL : f->presets[preset].presetName);


### PR DESCRIPTION
Potential fix for [https://github.com/earlephilhower/ESP8266Audio/security/code-scanning/9](https://github.com/earlephilhower/ESP8266Audio/security/code-scanning/9)

To fix the issue, the array access should only happen after confirming that the index is valid. Specifically, change the condition in line 1874 from

```c
if (f->presets[preset].regions == NULL && preset >= 0 && preset < f->presetNum)
```

to

```c
if (preset >= 0 && preset < f->presetNum && f->presets[preset].regions == NULL)
```

This ensures that no matter what value `preset` has, `f->presets[preset]` is only accessed after confirming it's within range.

Edit only the conditional in `tsf_get_presetname` as shown above. No new methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
