### PR TITLE
Mixer stubs produce 16b, avoid 8b WAV issues

### DIFF
--- a/src/AudioOutputMixer.cpp
+++ b/src/AudioOutputMixer.cpp
@@ -53,7 +53,6 @@ bool AudioOutputMixerStub::begin() {
 }
 
 bool AudioOutputMixerStub::ConsumeSample(int16_t sample[2]) {
-    int16_t amp[2];
     int16_t ms[2];
 
     ms[0] = sample[0];


### PR DESCRIPTION
Fixes #648