### PR TITLE
Fix PDM compiles for older SOCs

### DIFF
--- a/src/AudioOutputPDM.cpp
+++ b/src/AudioOutputPDM.cpp
@@ -66,7 +66,9 @@ bool AudioOutputPDM::begin() {
         .gpio_cfg = {
             .clk = I2S_GPIO_UNUSED,
             .dout = (gpio_num_t)pdmPin,
+#if SOC_I2S_PDM_MAX_TX_LINES > 1
             .dout2 = I2S_GPIO_UNUSED,
+#endif
             .invert_flags = {
                 .clk_inv = false,
             },


### PR DESCRIPTION
Espressif changes the contents of the PDM struct depending on the chip model.  Use a hopefully valid `#define` to avoid setting a member that's not there in some cases.

Fixes #785