### PR TITLE
Re-add -Werror on ESP32 CI

### DIFF
--- a/.github/workflows/pr-or-master-push.yml
+++ b/.github/workflows/pr-or-master-push.yml
@@ -103,8 +103,7 @@ jobs:
         cp -a /home/runner/work/ESP8266Audio/ESP8266Audio ~/Arduino/libraries/.
     - name: Build examples ESP32C6
       run: |
-        # TODO - Don't use -Werror on ESP32, I2S deprecation warnings
-        ./tests/build-ci.sh esp32c6 ${{matrix.shift}} "esp32:esp32:esp32c6:PartitionScheme=huge_app" 0
+        ./tests/build-ci.sh esp32c6 ${{matrix.shift}} "esp32:esp32:esp32c6:PartitionScheme=huge_app" 1
 
 # Run host test suite under valgrind for runtime checking of code.
   host-tests:

--- a/src/AudioOutputPDM.cpp
+++ b/src/AudioOutputPDM.cpp
@@ -61,7 +61,7 @@ bool AudioOutputPDM::begin() {
     assert(ESP_OK == i2s_new_channel(&chan_cfg, &_tx_handle, nullptr));
 
     i2s_pdm_tx_config_t pdm_cfg = {
-        .clk_cfg = I2S_PDM_TX_CLK_DEFAULT_CONFIG(AdjustI2SRate(hertz)),
+        .clk_cfg = I2S_PDM_TX_CLK_DEFAULT_CONFIG((uint32_t)AdjustI2SRate(hertz)),
         .slot_cfg = I2S_PDM_TX_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
         .gpio_cfg = {
             .clk = I2S_GPIO_UNUSED,


### PR DESCRIPTION
We no longer use the deprecated I2S APIs