### PR TITLE
Call i2s_channel_enable(_tx_handle) in AudioOutputSPDIF::begin()

### DIFF
--- a/src/AudioOutputSPDIF.cpp
+++ b/src/AudioOutputSPDIF.cpp
@@ -148,6 +148,7 @@ bool AudioOutputSPDIF::begin() {
     std_cfg.clk_cfg.clk_src = i2s_clock_src_t::I2S_CLK_SRC_APLL;
 #endif
     assert(ESP_OK == i2s_channel_init_std_mode(_tx_handle, &std_cfg));
+    assert(ESP_OK == i2s_channel_enable(_tx_handle));
 #else
     if (!I2SDriver.begin(_buffers, _bufferWords)) {
         audioLogger->println(F("ERROR: Unable to start I2S driver"));


### PR DESCRIPTION
Currently, `i2s_channel_enable(_tx_handle)` is only called within AudioOutputSPDIF::SetRate(), which caused i2s_channel_write() to fail with the following error when the source rate is accidentally the same with the default 44100Hz.
```
i2s_common: i2s_channel_write(1317): The channel is not enabled
```

This fixes the issue by enabling the i2s channel in AudioOutputSPDIF::begin().