### PR TITLE
Fix u8 upsampling and mono mode for AudioGeneratorWAV

### DIFF
--- a/src/AudioGeneratorWAV.cpp
+++ b/src/AudioGeneratorWAV.cpp
@@ -87,22 +87,21 @@ bool AudioGeneratorWAV::loop() {
     // Try and stuff the buffer one sample at a time
     do {
         if (bitsPerSample == 8) {
-            uint8_t l, r;
-            if (!GetBufferedData(1, &l)) {
+            uint8_t u8s; // For read u8 sample
+            if (!GetBufferedData(1, &u8s)) {
                 stop();
             }
+            // Upsample from unsigned 8 bits to signed 16 bits
+            lastSample[AudioOutput::LEFTCHANNEL] = ((int16_t)u8s - 128) << 8;
             if (channels == 2) {
-                if (!GetBufferedData(1, &r)) {
+                if (!GetBufferedData(1, &u8s)) {
                     stop();
                 }
+                // Upsample from unsigned 8 bits to signed 16 bits
+                lastSample[AudioOutput::RIGHTCHANNEL] = ((int16_t)u8s - 128) << 8;
             } else {
-                r = 0;
+                lastSample[AudioOutput::RIGHTCHANNEL] = lastSample[AudioOutput::LEFTCHANNEL];
             }
-
-            // Upsample from unsigned 8 bits to signed 16 bits
-            lastSample[AudioOutput::LEFTCHANNEL] = (((int16_t)(lastSample[AudioOutput::LEFTCHANNEL] & 0xff)) - 128) << 8;
-            lastSample[AudioOutput::RIGHTCHANNEL] = (((int16_t)(lastSample[AudioOutput::RIGHTCHANNEL] & 0xff)) - 128) << 8;
-
         } else if (bitsPerSample == 16) {
             if (!GetBufferedData(2, &lastSample[AudioOutput::LEFTCHANNEL])) {
                 stop();
@@ -112,7 +111,7 @@ bool AudioGeneratorWAV::loop() {
                     stop();
                 }
             } else {
-                lastSample[AudioOutput::RIGHTCHANNEL] = 0;
+                lastSample[AudioOutput::RIGHTCHANNEL] = lastSample[AudioOutput::LEFTCHANNEL];
             }
         }
     } while (running && output->ConsumeSample(lastSample));


### PR DESCRIPTION
Fixed the upsampling from `u8` to `i16` in `AudioGeneratorWAV`. Previously, playback of `WAV files` with `u8 encoding` resulted in silence because the data was being read but not actually used in the output calculations.

Additionally, improved mono mode handling.
Removed unnecessary resolution calculations for the second channel.
Implemented simple channel duplication.
Now, when playing mono `WAV files`, the audio is correctly output to both left and right channels.

__How to test:__
Use the `PlayWAVFromPROGMEM` example with a file converted via:
`ffmpeg -i viola.wav -acodec pcm_u8 -ac 1 -ar 44100 viola_u8_mono_44100.wav`
* Before: Silence.
* After: Clear audio in both channels.