### PR TITLE
Fix memory corruption in AudioGeneratorAAC on non-ESP8266 platforms

### DIFF
--- a/src/AudioGeneratorAAC.cpp
+++ b/src/AudioGeneratorAAC.cpp
@@ -31,7 +31,7 @@ AudioGeneratorAAC::AudioGeneratorAAC() {
     output = NULL;
 
     buff = (uint8_t*)malloc(buffLen);
-    outSample = (int16_t*)malloc(1024 * 2 * sizeof(uint16_t));
+    outSample = (int16_t*)malloc(outSampleLen * sizeof(uint16_t));
     if (!buff || !outSample) {
         audioLogger->printf_P(PSTR("ERROR: Out of memory in AAC\n"));
         Serial.flush();
@@ -63,7 +63,7 @@ AudioGeneratorAAC::AudioGeneratorAAC(void *preallocateData, int preallocateSz) {
     buff = (uint8_t*) p;
     p += (buffLen + 7) & ~7;
     outSample = (int16_t*) p;
-    p += (1024 * 2 * sizeof(int16_t) + 7) & ~7;
+    p += (outSampleLen * sizeof(int16_t) + 7) & ~7;
     int used = p - (uint8_t*)preallocateSpace;
     int availSpace = preallocateSize - used;
     if (availSpace < 0) {
@@ -212,7 +212,7 @@ bool AudioGeneratorAAC::begin(AudioFileSource *source, AudioOutput *output) {
     output->begin();
 
     memset(buff, 0, buffLen);
-    memset(outSample, 0, 1024 * 2 * sizeof(int16_t));
+    memset(outSample, 0, outSampleLen * sizeof(int16_t));
 
 
     running = true;

--- a/src/AudioGeneratorAAC.h
+++ b/src/AudioGeneratorAAC.h
@@ -49,7 +49,12 @@ protected:
     bool FillBufferWithValidFrame(); // Read until we get a valid syncword and min(feof, 2048) butes in the buffer
 
     // Output buffering
-    int16_t *outSample; //[1024 * 2]; // Interleaved L/R
+#ifdef ESP8266
+    const int outSampleLen = 1024 * 2;  // SBR disabled
+#else
+    const int outSampleLen = 2048 * 2;  // SBR enabled
+#endif
+    int16_t *outSample; //[1024 * 2] or [2048 * 2]; // Interleaved L/R
     int16_t validSamples;
     int16_t curSample;
 

--- a/tests/host/aac.cpp
+++ b/tests/host/aac.cpp
@@ -12,8 +12,8 @@ int main(int argc, char **argv)
     AudioFileSourceSTDIO *in = new AudioFileSourceSTDIO(AAC);
     AudioOutputSTDIO *out = new AudioOutputSTDIO();
     out->SetFilename("out.aac.wav");
-    void *space = malloc(28000+60000);
-    AudioGeneratorAAC *aac = new AudioGeneratorAAC(space, 28000+60000);
+    void *space = malloc(28000+60000+2048);
+    AudioGeneratorAAC *aac = new AudioGeneratorAAC(space, 28000+60000+2048);
 
     aac->begin(in, out);
     while (aac->loop()) { /*noop*/ }


### PR DESCRIPTION
The description of `AACDecode()` function states that the output buffer must be big enough for 1024 samples per channel _or_ 2048 if SBR is enabled. By default SBR is enabled on non-ESP8266 platforms, yet the buffer in `AudioGeneratorAAC` is always 1024 samples per channel long. This causes memory corruption on ESP32 and possibly Pi Pico. This change makes the output buffer correct.